### PR TITLE
Dev - Segment pseudo unique names.

### DIFF
--- a/helpers.mk
+++ b/helpers.mk
@@ -299,7 +299,7 @@ ifneq (${DEBUG},)
 define ${_macro}
   $(call Log-Message,dbug,$(1))
 endef
-__V:=vp --warn-undefined-variables
+__V:=--debug=vp --warn-undefined-variables
 endif
 
 _macro := Step
@@ -429,7 +429,7 @@ define ${_macro}
   $(call Exit-Macro)
 endef
 
-MAKEFLAGS += --debug=${__V}
+MAKEFLAGS += ${__V}
 
 _var := Error_Callback
 define _help
@@ -613,7 +613,7 @@ $(strip \
   $(call Enter-Macro,$(0),$(1))
   $(call Debug,Requiring defined variables:$(1))
   $(eval __r :=)
-  $(foreach _v,$(1),
+  $(foreach __v,$(1),
     $(call Debug,Requiring: ${__v})
     $(if $(findstring undefined,$(flavor ${__v})),
       $(eval __r += ${__v})
@@ -1688,7 +1688,7 @@ define ${_macro}
     $(eval undefine $(1))
     $(shell rm ${STICKY_PATH}/$(1))
   ,
-    $(call Debug,Var $(1) has not been defined.)\
+    $(call Signal-Error,Var $(1) has not been defined.)\
   )
   $(call Exit-Macro)
 endef

--- a/helpers.mk
+++ b/helpers.mk
@@ -1148,7 +1148,7 @@ define ${_macro}
 # $(strip $(2))
 #----------------------------------------------------------------------------
 # +++++
-$(call Last-Segment-UN)
+$$(call Last-Segment-UN)
 $.ifndef $${LastSegUN}.SegID
 $$(call Enter-Segment)
 # -----

--- a/helpers.mk
+++ b/helpers.mk
@@ -1193,8 +1193,9 @@ $${LastSegUN}: $${SegF}
 # +++++
 # Postamble
 # Define help only if needed.
-$.ifneq ($$(call Is-Goal,help-$${SegUN}),)
-$.define help_$${SegV}_msg
+$.__h := $$(or $$(call Is-Goal,help-$${SegUN}),$$(call Is-Goal,help-$${SegID}))
+$.ifneq ($${__h},)
+$.define __help
 Make segment: $${Seg}.mk
 
 # Place overview here.
@@ -1202,13 +1203,10 @@ Make segment: $${Seg}.mk
 # Add help messages here.
 
 Defines:
-${help-$(1).init}
 
   # Describe each variable or macro.
 
 Command line goals:
-  $${SegUN}
-    Build this component.
   # Describe additional goals provided by the segment.
   help-$${SegUN}
     Display this help.

--- a/helpers.mk
+++ b/helpers.mk
@@ -1147,11 +1147,9 @@ define ${_macro}
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 # $(strip $(2))
 #----------------------------------------------------------------------------
-# The prefix $(1) must be unique for all files.
-# The format of all the $(1) based names is required.
 # +++++
 $(call Last-Segment-UN)
-$.ifndef $(1).SegID
+$.ifndef $${LastSegUN}.SegID
 $$(call Enter-Segment)
 # -----
 

--- a/helpers.mk
+++ b/helpers.mk
@@ -1056,6 +1056,18 @@ $.ifndef $(1).SegID
 $$(call Enter-Segment)
 # -----
 
+_macro := $(1).init
+$.define _help
+$${_macro}
+  Run the initialization for the segment. This is designed to be called
+  immediately after the segment has been loaded.
+$.endef
+$.define $${_macro}
+$$(call Enter-Macro,$$(0),$$(1))
+$$(call Info,Initializing $(1).)
+$$(call Exit-Macro)
+$.endef
+
 $$(call Info,New segment: Add variables, macros, goals, and recipes here.)
 
 # The command line goal for the segment.
@@ -1073,6 +1085,8 @@ Make segment: $${Seg}.mk
 # Add help messages here.
 
 Defines:
+${help-$(1).init}
+
   # Describe each variable or macro.
 
 Command line goals:
@@ -1115,13 +1129,13 @@ ${_macro}
   Parameters:
     1 = The segment name. This is used to name the segment file, associated
         variable and, specific goals.
-    2 = A one line description.
-    3 = The full path to where to write the segment file.
+    2 = The full path to where to write the segment file.
+    3 = A one line description.
 endef
 help-${_macro} := $(call _help)
 define ${_macro}
   $(call Enter-Macro,$(0),$(1) $(2) $(3))
-  $(file >$(3),$(call Gen-Segment-Text,$(1),$(2)))
+  $(file >$(2),$(call Gen-Segment-Text,$(1),$(3)))
   $(call Exit-Macro)
 endef
 #--------------
@@ -1283,7 +1297,7 @@ ${_macro}
         semicolons (;) or AND (&&) OR (||) conditionals.
   Returns:
     Run_Output
-      The console output with the return code appended at the enf of the last
+      The console output with the return code appended at the end of the last
       line.
     Run_Rc
       The return code from the output.
@@ -1378,7 +1392,9 @@ define _help
 ${_macro}
   A sticky variable is persistent and needs to be defined on the command line
   at least once or have a default value as an argument.
-  If the variable has not been defined when this macro is called then the previous value is used. Defining the variable will overwrite the previous sticky value.
+  If the variable has not been defined when this macro is called then the
+  previous value is used. Defining the variable will overwrite the previous
+  sticky value.
   Only the first call to Sticky for a given variable will be accepted.
   Additional calls will produce a redefinition error.
   Sticky variables are read only in a sub-make (MAKELEVEL != 0).
@@ -1396,11 +1412,13 @@ ${_macro}
     The variable value.
   Examples:
     $$(call Sticky,<var>,<default>)
-      Restores the previously saved <value> or sets <var> equal to
-      <default>.
+      If <var> is undefined then restores the previously saved <value> or sets
+      <var> equal to <default>.
+      If <var> is defined then <var> is saved as a new value.
     $$(call Sticky,<var>=<value>)
       Sets the sticky variable equal to <value>. The <value> is saved
-      for retrieval at a later time.
+      for retrieval at a later time. NOTE: This form can override the variable
+      if it was defined before calling Sticky (e.g on the command line).
     $$(call Sticky,<var>=<value>,<default>)
       Sets the sticky variable equal to <value>. The <value> is saved
       for retrieval at a later time. The default is ignored in this case.

--- a/makefile
+++ b/makefile
@@ -1,6 +1,5 @@
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-# helpers - A set of helper scripts and utilities designed to be used by
-# other projects.
+# Test the helpers.
 #----------------------------------------------------------------------------
 #VERBOSE=1
 #DEBUG=1
@@ -9,6 +8,8 @@ TmpTestPath := /tmp/test-helpers
 LOG_PATH := ${TmpTestPath}/log
 
 STICKY_PATH := ${TmpTestPath}/sticky
+
+MakeD := Run the test suites to test the helpers.
 
 include helpers.mk
 
@@ -19,13 +20,18 @@ $(call Use-Segment,test-helpers)
 
 $(call Run-Suites,${SUITES_PATH},${CASES})
 
-$(call Resolve-Help-Goals)
+$(call Display-Segs)
 
 clean:
 > rm -rf ${TmpTestPath}
 
-ifneq ($(filter help,$(Goals)),)
-define help-Usage
+__h := $(or \
+  $(call Is-Goal,help-${SegUN}), \
+  $(call Is-Goal,help-${SegID}))
+ifneq (${__h},)
+$(call Attention,Defining ${__h} for:${Seg})
+define __help
+Makefile: ${Seg}
 Usage: make [<option>=<value> ...] [<goal> [<goal> ...]]
 
 NOTE: This help is displayed if no goal is specified.
@@ -39,5 +45,6 @@ information.
 Use the test goal. See help-test-helpers for more information.
 
 endef
-
+${__h} := ${__help}
 endif
+$(call Resolve-Help-Goals)

--- a/seg-template.mk
+++ b/seg-template.mk
@@ -1,7 +1,6 @@
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 # <purpose for this segment>
 #----------------------------------------------------------------------------
-# The prefix $(call Last-Segment-Basename) must be unique for all files.
 # +++++
 $(call Last-Segment-UN)
 ifndef ${LastSegUN}.SegID

--- a/seg-template.mk
+++ b/seg-template.mk
@@ -4,23 +4,40 @@
 # +++++
 $(call Last-Segment-UN)
 ifndef ${LastSegUN}.SegID
-$(call Enter-Segment)
+$(call Enter-Segment,<purpose for this segment>.)
 # -----
+
+_macro := ${SegUN}.init
+$.define _help
+${_macro}
+  Run the initialization for the segment. This is designed to be called
+  some time after the segment has been loaded. This is useful when this
+  segment uses variables from other segments which haven't been loaded.
+$.endef
+$.define ${_macro}
+$(call Enter-Macro,$(0),$(1))
+$(call Info,Initializing $(1).)
+$(call Exit-Macro)
+$.endef
+
+$$(call Info,New segment: Add variables, macros, goals, and recipes here.)
 
 <segment body here>
 
 # +++++
 # Postamble
 # Define help only if needed.
-ifneq ($(call Is-Goal,help-${Seg}),)
-define help-${Seg}
+__h := $(or $(call Is-Goal,help-${SegUN}),$(call Is-Goal,help-${SegID}))
+ifneq (${__h},)
+define __help
 Make segment: ${Seg}.mk
 
 <make segment help messages>
 
 Command line goals:
-  help-${Seg}   Display this help.
+  help-${SegUN}   Display this help.
 endef
+${__h} := ${__help}
 endif # help goal message.
 
 $(call Exit-Segment)

--- a/seg-template.mk
+++ b/seg-template.mk
@@ -3,8 +3,8 @@
 #----------------------------------------------------------------------------
 # The prefix $(call Last-Segment-Basename) must be unique for all files.
 # +++++
-# Preamble
-ifndef $(call Last-Segment-Basename).SegID
+$(call Last-Segment-UN)
+ifndef ${LastSegUN}.SegID
 $(call Enter-Segment)
 # -----
 

--- a/suite-template.mk
+++ b/suite-template.mk
@@ -7,7 +7,7 @@ ifndef ${LastSegUN}.SegID
 $(call Enter-Segment,<purpose for this test suite segment>.)
 # -----
 
-$(call Declare-Suite,${SegUN},<description>)
+$(call Declare-Suite,${Seg},<description>)
 
 ${.SuiteN}.Prereqs :=
 

--- a/suite-template.mk
+++ b/suite-template.mk
@@ -4,10 +4,10 @@
 # +++++
 $(call Last-Segment-UN)
 ifndef ${LastSegUN}.SegID
-$(call Enter-Segment)
+$(call Enter-Segment,<purpose for this test suite segment>.)
 # -----
 
-$(call Declare-Suite,${Seg},<description>)
+$(call Declare-Suite,${SegUN},<description>)
 
 ${.SuiteN}.Prereqs :=
 
@@ -35,19 +35,21 @@ $(call End-Declare-Suite)
 # +++++
 # Postamble
 # Define help only if needed.
-#ifneq ($(call Is-Goal,help-${Seg}),)
-define help-${Seg}
+__h := $(or $(call Is-Goal,help-${SegUN}),$(call Is-Goal,help-${SegID}))
+ifneq (${__h},)
+define __help
 Make test suite: ${Seg}.mk
 
 <make test suite help messages>
 
 Command line goals:
-  help-${Seg}
+  help-${SegUN}
     Display this help.
-  show-${Seg}.TestL
+  show-${SegUN}.TestL
     Display the list of tests included in this suite.
 endef
-#endif # help goal message.
+${__h} := ${__help}
+endif # help goal message.
 
 $(call Exit-Segment)
 else # <u>SegID exists

--- a/suite-template.mk
+++ b/suite-template.mk
@@ -3,8 +3,8 @@
 #----------------------------------------------------------------------------
 # The prefix $(call Last-Segment-Basename) must be unique for all files.
 # +++++
-# Preamble
-ifndef $(call Last-Segment-Basename).SegID
+$(call Last-Segment-UN)
+ifndef ${LastSegUN}.SegID
 $(call Enter-Segment)
 # -----
 

--- a/suite-template.mk
+++ b/suite-template.mk
@@ -1,7 +1,6 @@
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 # <purpose for this test suite segment>
 #----------------------------------------------------------------------------
-# The prefix $(call Last-Segment-Basename) must be unique for all files.
 # +++++
 $(call Last-Segment-UN)
 ifndef ${LastSegUN}.SegID

--- a/test-helpers.mk
+++ b/test-helpers.mk
@@ -1,11 +1,12 @@
 #+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-# This make segment is designed to test helpers.mk.
+# Use this to help test macros and variables.
 #-----------------------------------------------------------------------------
 # +++++
 $(call Last-Segment-UN)
 $(call Debug,$(call Last-Segment-Basename) UN:${LastSegUN})
 ifndef ${LastSegUN}.SegID
-$(call Enter-Segment)
+$(call Enter-Segment,\
+  Test helpers for testing makefile segments and macros.)
 # -----
 
 DEFAULT_SUITES_PATH := test-suites
@@ -686,11 +687,13 @@ define ${_macro}
     SegV \
     SegP \
     SegF \
-    ${Seg}.SegID \
-    ${Seg}.Seg \
-    ${Seg}.SegV \
-    ${Seg}.SegP \
-    ${Seg}.SegF \
+    SegD \
+    ${SegUN}.SegID \
+    ${SegUN}.Seg \
+    ${SegUN}.SegV \
+    ${SegUN}.SegP \
+    ${SegUN}.SegF \
+    ${SegUN}.SegD \
   )
 
   $(call Test-Info,\
@@ -703,13 +706,13 @@ define ${_macro}
   Get-Segment-Path:SegID:$(call Get-Segment-Path,${SegID}))
 
   $(call Test-Info,\
-  Get-Segment-File:${Seg}.SegID:$(call Get-Segment-File,${${Seg}.SegID}))
+  Get-Segment-File:${SegUN}.SegID:$(call Get-Segment-File,${${SegUN}.SegID}))
   $(call Test-Info,\
-  Get-Segment-Basename:${Seg}.SegID:$(call Get-Segment-Basename,${${Seg}.SegID}))
+  Get-Segment-Basename:${SegUN}.SegID:$(call Get-Segment-Basename,${${SegUN}.SegID}))
   $(call Test-Info,\
-  Get-Segment-Var:${Seg}.SegID:$(call Get-Segment-Var,${${Seg}.SegID}))
+  Get-Segment-Var:${SegUN}.SegID:$(call Get-Segment-Var,${${SegUN}.SegID}))
   $(call Test-Info,\
-  Get-Segment-Path:${Seg}.SegID:$(call Get-Segment-Path,${${Seg}.SegID}))
+  Get-Segment-Path:${SegUN}.SegID:$(call Get-Segment-Path,${${SegUN}.SegID}))
 
   $(call Test-Info,Last-Segment-Id:$(call Last-Segment-Id))
   $(call Test-Info,Last-Segment-Basename:$(call Last-Segment-Basename))
@@ -1161,7 +1164,7 @@ define ${_macro}
     $(if ${_s},
       $(eval _suite := ${_s})
     ,
-      $(eval _suite := ${Seg})
+      $(eval _suite := ${SegUN})
     )
     $(if ${${_suite}.ID},
       $(call Verbose,Test suite ${_suite} has already been initialized.)
@@ -1260,8 +1263,12 @@ test:
 
 # +++++
 # Postamble
-ifneq ($(call Is-Goal,help-${Seg}),)
-define help-${Seg}
+__h := $(or $(call Is-Goal,help-${SegUN}),$(call Is-Goal,help-${SegID}))
+ifneq (${__h},)
+$(call Attention,Generating help for:${Seg})
+define __help
+Makefile segment: ${Seg}.mk
+
 This make segment provides test support macros. These are designed to run
 before any goals are processed and when makefile segments are loaded. The
 concept is similar to that of a C preprocessor.
@@ -1381,7 +1388,7 @@ Test results:
 
 Test implementation recommendations:
   For consistency and to help avoid naming conflicts each test suite should
-  be contained in a single makefile segment. The name of the segment ($${Seg})
+  be contained in a single makefile segment. The name of the segment ($${SegUN})
   can then be passed to Declare-Suite to serve as the suite name (SuiteN). This
   is most important when using Use-Segment to load test suites to avoid loading
   the same suite more than once. Declare-Test uses .SuiteN as a prefix for
@@ -1491,7 +1498,7 @@ Goals:
       Use this goal to run all of the specified test suites.
 
 endef
-$(call Test-Info,help-${Seg})
+${__h} := ${__help}
 endif
 $(call Exit-Segment)
 else # SegID exists

--- a/test-helpers.mk
+++ b/test-helpers.mk
@@ -1164,10 +1164,10 @@ define ${_macro}
     $(if ${_s},
       $(eval _suite := ${_s})
     ,
-      $(eval _suite := ${SegUN})
+      $(eval _suite := ${Seg})
     )
     $(if ${${_suite}.ID},
-      $(call Verbose,Test suite ${_suite} has already been initialized.)
+      $(call Verbose,Test suite ${_suite} has already been loaded.)
     ,
       $(if $(wildcard ${SUITES_PATH}/${_suite}.mk),
         $(call Use-Segment,${_suite})

--- a/test-helpers.mk
+++ b/test-helpers.mk
@@ -1,10 +1,10 @@
 #+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-# This make segment is designed to test macros.mk.
+# This make segment is designed to test helpers.mk.
 #-----------------------------------------------------------------------------
-# The prefix $(call Last-Segment-Basename) must be unique for all files.
 # +++++
-# Preamble
-ifndef $(call Last-Segment-Basename).SegID
+$(call Last-Segment-UN)
+$(call Debug,$(call Last-Segment-Basename) UN:${LastSegUN})
+ifndef ${LastSegUN}.SegID
 $(call Enter-Segment)
 # -----
 

--- a/test-segs/d1/td1.mk
+++ b/test-segs/d1/td1.mk
@@ -4,7 +4,7 @@
 # +++++
 $(call Last-Segment-UN)
 ifndef ${LastSegUN}.SegID
-$(call Enter-Segment)
+$(call Enter-Segment,For test only.)
 # -----
 
 $(call Test-Info,Path:$(call Last-Segment-Path))
@@ -12,16 +12,18 @@ $(call Expect-Vars,Seg:td1 td1Seg:td1)
 
 # +++++
 # Postamble
-ifneq ($(call Is-Goal,help-${Seg}),)
-$(call test-message,Help message variable: help-${Seg})
-define help-${Seg}
+__h := $(or $(call Is-Goal,help-${SegUN}),$(call Is-Goal,help-${SegID}))
+ifneq (${__h},)
+$(call Attention,Generating help for:${Seg})
+define __help
 Make segment: ${Seg}.mk
 
 This segment is in the helpers directory and is intended for test only.
 
 Command line goals:
-  help-${Seg}   Display this help.
+  help-${SegUN}   Display this help.
 endef
+${__h} := ${__help}
 endif
 $(call Exit-Segment)
 else

--- a/test-segs/d1/td1.mk
+++ b/test-segs/d1/td1.mk
@@ -1,7 +1,6 @@
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 # For test only.
 #----------------------------------------------------------------------------
-# The prefix $(call Last-Segment-Basename) must be unique for all files.
 # +++++
 $(call Last-Segment-UN)
 ifndef ${LastSegUN}.SegID

--- a/test-segs/d1/td1.mk
+++ b/test-segs/d1/td1.mk
@@ -3,8 +3,8 @@
 #----------------------------------------------------------------------------
 # The prefix $(call Last-Segment-Basename) must be unique for all files.
 # +++++
-# Preamble
-ifndef $(call Last-Segment-Basename).SegID
+$(call Last-Segment-UN)
+ifndef ${LastSegUN}.SegID
 $(call Enter-Segment)
 # -----
 

--- a/test-segs/d1/tm1.mk
+++ b/test-segs/d1/tm1.mk
@@ -1,7 +1,6 @@
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 # For test only.
 #----------------------------------------------------------------------------
-# The prefix $(call Last-Segment-Basename) must be unique for all files.
 # +++++
 $(call Last-Segment-UN)
 ifndef ${LastSegUN}.SegID

--- a/test-segs/d1/tm1.mk
+++ b/test-segs/d1/tm1.mk
@@ -3,8 +3,8 @@
 #----------------------------------------------------------------------------
 # The prefix $(call Last-Segment-Basename) must be unique for all files.
 # +++++
-# Preamble
-ifndef $(call Last-Segment-Basename).SegID
+$(call Last-Segment-UN)
+ifndef ${LastSegUN}.SegID
 $(call Enter-Segment)
 # -----
 

--- a/test-segs/d1/tm1.mk
+++ b/test-segs/d1/tm1.mk
@@ -4,7 +4,7 @@
 # +++++
 $(call Last-Segment-UN)
 ifndef ${LastSegUN}.SegID
-$(call Enter-Segment)
+$(call Enter-Segment,For test only.)
 # -----
 
 $(call Test-Info,Path:$(call Last-Segment-Path))
@@ -12,16 +12,18 @@ $(call Expect-Vars,Seg:tm1 tm1Seg:tm1)
 
 # +++++
 # Postamble
-ifneq ($(call Is-Goal,help-${Seg}),)
-$(call test-message,Help message variable: help-${Seg})
-define help-${Seg}
+__h := $(or $(call Is-Goal,help-${SegUN}),$(call Is-Goal,help-${SegID}))
+ifneq (${__h},)
+$(call Attention,Generating help for:${Seg})
+define __help
 Make segment: ${Seg}.mk
 
 This segment is in the helpers directory and is intended for test only.
 
 Command line goals:
-  help-${Seg}   Display this help.
+  help-${SegUN}   Display this help.
 endef
+${__h} := ${__help}
 endif
 $(call Exit-Segment)
 else

--- a/test-segs/d2/td2.mk
+++ b/test-segs/d2/td2.mk
@@ -1,7 +1,6 @@
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 # For test only.
 #----------------------------------------------------------------------------
-# The prefix $(call Last-Segment-Basename) must be unique for all files.
 # +++++
 $(call Last-Segment-UN)
 ifndef ${LastSegUN}.SegID

--- a/test-segs/d2/td2.mk
+++ b/test-segs/d2/td2.mk
@@ -3,8 +3,8 @@
 #----------------------------------------------------------------------------
 # The prefix $(call Last-Segment-Basename) must be unique for all files.
 # +++++
-# Preamble
-ifndef $(call Last-Segment-Basename).SegID
+$(call Last-Segment-UN)
+ifndef ${LastSegUN}.SegID
 $(call Enter-Segment)
 # -----
 

--- a/test-segs/d2/td2.mk
+++ b/test-segs/d2/td2.mk
@@ -4,7 +4,7 @@
 # +++++
 $(call Last-Segment-UN)
 ifndef ${LastSegUN}.SegID
-$(call Enter-Segment)
+$(call Enter-Segment,For test only.)
 # -----
 
 $(call Test-Info,Path:$(call Last-Segment-Path))
@@ -12,16 +12,18 @@ $(call Expect-Vars,Seg:td2 td2Seg:td2)
 
 # +++++
 # Postamble
-ifneq ($(call Is-Goal,help-${Seg}),)
-$(call test-message,Help message variable: help-${Seg})
-define help-${Seg}
+__h := $(or $(call Is-Goal,help-${SegUN}),$(call Is-Goal,help-${SegID}))
+ifneq (${__h},)
+$(call Attention,Generating help for:${Seg})
+define __help
 Make segment: ${Seg}.mk
 
 This segment is in the helpers directory and is intended for test only.
 
 Command line goals:
-  help-${Seg}   Display this help.
+  help-${SegUN}   Display this help.
 endef
+${__h} := ${__help}
 endif
 $(call Exit-Segment)
 else

--- a/test-segs/d2/tm1.mk
+++ b/test-segs/d2/tm1.mk
@@ -1,7 +1,6 @@
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 # For test only.
 #----------------------------------------------------------------------------
-# The prefix $(call Last-Segment-Basename) must be unique for all files.
 # +++++
 $(call Last-Segment-UN)
 ifndef ${LastSegUN}.SegID

--- a/test-segs/d2/tm1.mk
+++ b/test-segs/d2/tm1.mk
@@ -3,8 +3,8 @@
 #----------------------------------------------------------------------------
 # The prefix $(call Last-Segment-Basename) must be unique for all files.
 # +++++
-# Preamble
-ifndef $(call Last-Segment-Basename).SegID
+$(call Last-Segment-UN)
+ifndef ${LastSegUN}.SegID
 $(call Enter-Segment)
 # -----
 

--- a/test-segs/d2/tm1.mk
+++ b/test-segs/d2/tm1.mk
@@ -4,7 +4,7 @@
 # +++++
 $(call Last-Segment-UN)
 ifndef ${LastSegUN}.SegID
-$(call Enter-Segment)
+$(call Enter-Segment,For test only.)
 # -----
 
 $(call Test-Info,Path:$(call Last-Segment-Path))
@@ -12,16 +12,18 @@ $(call Expect-Vars,Seg:tm1 tm1Seg:tm1)
 
 # +++++
 # Postamble
-ifneq ($(call Is-Goal,help-${Seg}),)
-$(call test-message,Help message variable: help-${Seg})
-define help-${Seg}
+__h := $(or $(call Is-Goal,help-${SegUN}),$(call Is-Goal,help-${SegID}))
+ifneq (${__h},)
+$(call Attention,Generating help for:${Seg})
+define __help
 Make segment: ${Seg}.mk
 
 This segment is in the helpers directory and is intended for test only.
 
 Command line goals:
-  help-${Seg}   Display this help.
+  help-${SegUN}   Display this help.
 endef
+${__h} := ${__help}
 endif
 $(call Exit-Segment)
 else

--- a/test-segs/d2/tm2.mk
+++ b/test-segs/d2/tm2.mk
@@ -1,7 +1,6 @@
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 # For test only.
 #----------------------------------------------------------------------------
-# The prefix $(call Last-Segment-Basename) must be unique for all files.
 # +++++
 $(call Last-Segment-UN)
 ifndef ${LastSegUN}.SegID

--- a/test-segs/d2/tm2.mk
+++ b/test-segs/d2/tm2.mk
@@ -3,8 +3,8 @@
 #----------------------------------------------------------------------------
 # The prefix $(call Last-Segment-Basename) must be unique for all files.
 # +++++
-# Preamble
-ifndef $(call Last-Segment-Basename).SegID
+$(call Last-Segment-UN)
+ifndef ${LastSegUN}.SegID
 $(call Enter-Segment)
 # -----
 

--- a/test-segs/d2/tm2.mk
+++ b/test-segs/d2/tm2.mk
@@ -4,7 +4,7 @@
 # +++++
 $(call Last-Segment-UN)
 ifndef ${LastSegUN}.SegID
-$(call Enter-Segment)
+$(call Enter-Segment,For test only.)
 # -----
 
 $(call Test-Info,Path:$(call Last-Segment-Path))
@@ -12,16 +12,18 @@ $(call Expect-Vars,Seg:tm2 tm2Seg:tm2)
 
 # +++++
 # Postamble
-ifneq ($(call Is-Goal,help-${Seg}),)
-$(call test-message,Help message variable: help-${Seg})
-define help-${Seg}
+__h := $(or $(call Is-Goal,help-${SegUN}),$(call Is-Goal,help-${SegID}))
+ifneq (${__h},)
+$(call Attention,Generating help for:${Seg})
+define __help
 Make segment: ${Seg}.mk
 
 This segment is in the helpers directory and is intended for test only.
 
 Command line goals:
-  help-${Seg}   Display this help.
+  help-${SegUN}   Display this help.
 endef
+${__h} := ${__help}
 endif
 $(call Exit-Segment)
 else

--- a/test-segs/d3/sd3/tsd3.mk
+++ b/test-segs/d3/sd3/tsd3.mk
@@ -1,7 +1,6 @@
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 # For test only.
 #----------------------------------------------------------------------------
-# The prefix $(call Last-Segment-Basename) must be unique for all files.
 # +++++
 $(call Last-Segment-UN)
 ifndef ${LastSegUN}.SegID

--- a/test-segs/d3/sd3/tsd3.mk
+++ b/test-segs/d3/sd3/tsd3.mk
@@ -3,8 +3,8 @@
 #----------------------------------------------------------------------------
 # The prefix $(call Last-Segment-Basename) must be unique for all files.
 # +++++
-# Preamble
-ifndef $(call Last-Segment-Basename).SegID
+$(call Last-Segment-UN)
+ifndef ${LastSegUN}.SegID
 $(call Enter-Segment)
 # -----
 

--- a/test-segs/d3/sd3/tsd3.mk
+++ b/test-segs/d3/sd3/tsd3.mk
@@ -4,7 +4,7 @@
 # +++++
 $(call Last-Segment-UN)
 ifndef ${LastSegUN}.SegID
-$(call Enter-Segment)
+$(call Enter-Segment,For test only.)
 # -----
 
 $(call Test-Info,Path:$(call Last-Segment-Path))
@@ -12,16 +12,18 @@ $(call Expect-Vars,Seg:tsd3 tsd3Seg:tsd3)
 
 # +++++
 # Postamble
-ifneq ($(call Is-Goal,help-${Seg}),)
-$(call test-message,Help message variable: help-${Seg})
-define help-${Seg}
+__h := $(or $(call Is-Goal,help-${SegUN}),$(call Is-Goal,help-${SegID}))
+ifneq (${__h},)
+$(call Attention,Generating help for:${Seg})
+define __help
 Make segment: ${Seg}.mk
 
 This segment is in the helpers directory and is intended for test only.
 
 Command line goals:
-  help-${Seg}   Display this help.
+  help-${SegUN}   Display this help.
 endef
+${__h} := ${__help}
 endif
 $(call Exit-Segment)
 else

--- a/test-segs/d3/td3.mk
+++ b/test-segs/d3/td3.mk
@@ -1,7 +1,6 @@
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 # For test only.
 #----------------------------------------------------------------------------
-# The prefix $(call Last-Segment-Basename) must be unique for all files.
 # +++++
 $(call Last-Segment-UN)
 ifndef ${LastSegUN}.SegID

--- a/test-segs/d3/td3.mk
+++ b/test-segs/d3/td3.mk
@@ -4,7 +4,7 @@
 # +++++
 $(call Last-Segment-UN)
 ifndef ${LastSegUN}.SegID
-$(call Enter-Segment)
+$(call Enter-Segment,For test only.)
 # -----
 
 $(call Test-Info,Path:$(call Last-Segment-Path))
@@ -12,16 +12,18 @@ $(call Expect-Vars,Seg:td3 td3Seg:td3)
 
 # +++++
 # Postamble
-ifneq ($(call Is-Goal,help-${Seg}),)
-$(call test-message,Help message variable: help-${Seg})
-define help-${Seg}
+__h := $(or $(call Is-Goal,help-${SegUN}),$(call Is-Goal,help-${SegID}))
+ifneq (${__h},)
+$(call Attention,Generating help for:${Seg})
+define __help
 Make segment: ${Seg}.mk
 
 This segment is in the helpers directory and is intended for test only.
 
 Command line goals:
-  help-${Seg}   Display this help.
+  help-${SegUN}   Display this help.
 endef
+${__h} := ${__help}
 endif
 $(call Exit-Segment)
 else

--- a/test-segs/d3/td3.mk
+++ b/test-segs/d3/td3.mk
@@ -3,8 +3,8 @@
 #----------------------------------------------------------------------------
 # The prefix $(call Last-Segment-Basename) must be unique for all files.
 # +++++
-# Preamble
-ifndef $(call Last-Segment-Basename).SegID
+$(call Last-Segment-UN)
+ifndef ${LastSegUN}.SegID
 $(call Enter-Segment)
 # -----
 

--- a/test-segs/d3/tm2.mk
+++ b/test-segs/d3/tm2.mk
@@ -1,7 +1,6 @@
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 # For test only.
 #----------------------------------------------------------------------------
-# The prefix $(call Last-Segment-Basename) must be unique for all files.
 # +++++
 $(call Last-Segment-UN)
 ifndef ${LastSegUN}.SegID

--- a/test-segs/d3/tm2.mk
+++ b/test-segs/d3/tm2.mk
@@ -3,8 +3,8 @@
 #----------------------------------------------------------------------------
 # The prefix $(call Last-Segment-Basename) must be unique for all files.
 # +++++
-# Preamble
-ifndef $(call Last-Segment-Basename).SegID
+$(call Last-Segment-UN)
+ifndef ${LastSegUN}.SegID
 $(call Enter-Segment)
 # -----
 

--- a/test-segs/d3/tm2.mk
+++ b/test-segs/d3/tm2.mk
@@ -4,7 +4,7 @@
 # +++++
 $(call Last-Segment-UN)
 ifndef ${LastSegUN}.SegID
-$(call Enter-Segment)
+$(call Enter-Segment,For test only.)
 # -----
 
 $(call Test-Info,Path:$(call Last-Segment-Path))
@@ -12,16 +12,18 @@ $(call Expect-Vars,Seg:tm2 tm2Seg:tm2)
 
 # +++++
 # Postamble
-ifneq ($(call Is-Goal,help-${Seg}),)
-$(call test-message,Help message variable: help-${Seg})
-define help-${Seg}
+__h := $(or $(call Is-Goal,help-${SegUN}),$(call Is-Goal,help-${SegID}))
+ifneq (${__h},)
+$(call Attention,Generating help for:${Seg})
+define __help
 Make segment: ${Seg}.mk
 
 This segment is in the helpers directory and is intended for test only.
 
 Command line goals:
-  help-${Seg}   Display this help.
+  help-${SegUN}   Display this help.
 endef
+${__h} := ${__help}
 endif
 $(call Exit-Segment)
 else

--- a/test-segs/test-conflict.mk
+++ b/test-segs/test-conflict.mk
@@ -5,20 +5,21 @@ $(call Info,+++++ $(call Last-Segment-Basename) entry. +++++)
 # +++++
 $(call Last-Segment-UN)
 ifndef ${LastSegUN}.SegID
-$(call Enter-Segment)
+$(call Enter-Segment,Test detection of segment name conflict.)
 # -----
 
 #<segment body here>
 
 # +++++
 # Postamble
-ifneq ($(call Is-Goal,help-${Seg}),)
-$(call Info,Declaring help message for ${Seg}.)
-define help-${Seg}
+__h := $(or $(call Is-Goal,help-${SegUN}),$(call Is-Goal,help-${SegID}))
+ifneq (${__h},)
+define __help
 This make segment is designed to test detection of a prefix conflict between
 two or more files. Displaying this help should not be possible because this
 file uses the same prefix as test-macros.mk.
 endef
+${__h} := ${__help}
 endif
 
 $(call Exit-Segment)

--- a/test-segs/test-conflict.mk
+++ b/test-segs/test-conflict.mk
@@ -1,8 +1,6 @@
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 # Test detection of segment name conflict.
 #----------------------------------------------------------------------------
-# The prefix $(call Last-Segment-Basename) must be unique for all files.
-# This deliberately uses tm to force a conflict with test-macros.mk.
 $(call Info,+++++ $(call Last-Segment-Basename) entry. +++++)
 # +++++
 $(call Last-Segment-UN)

--- a/test-segs/test-conflict.mk
+++ b/test-segs/test-conflict.mk
@@ -5,8 +5,8 @@
 # This deliberately uses tm to force a conflict with test-macros.mk.
 $(call Info,+++++ $(call Last-Segment-Basename) entry. +++++)
 # +++++
-# Preamble
-ifndef $(call Last-Segment-Basename).SegID
+$(call Last-Segment-UN)
+ifndef ${LastSegUN}.SegID
 $(call Enter-Segment)
 # -----
 

--- a/test-segs/ts1.mk
+++ b/test-segs/ts1.mk
@@ -4,24 +4,26 @@
 # +++++
 $(call Last-Segment-UN)
 ifndef ${LastSegUN}.SegID
-$(call Enter-Segment)
+$(call Enter-Segment,For test only.)
 # -----
 
-$(call Info,${Seg}:Path:$(call Last-Segment-Path))
+$(call Info,${SegUN}:Path:$(call Last-Segment-Path))
 $(call Expect-Vars,Seg:ts1 ts1Seg:ts1)
 
 # +++++
 # Postamble
-ifneq ($(call Is-Goal,help-${Seg}),)
-$(call test-message,Help message variable: help-${Seg})
-define help-${Seg}
+__h := $(or $(call Is-Goal,help-${SegUN}),$(call Is-Goal,help-${SegID}))
+ifneq (${__h},)
+$(call Attention,Generating help for:${Seg})
+define __help
 Make segment: ${Seg}.mk
 
 This segment is in the helpers directory and is intended for test only.
 
 Command line goals:
-  help-${Seg}   Display this help.
+  help-${SegUN}   Display this help.
 endef
+${__h} := ${__help}
 endif
 $(call Exit-Segment)
 else

--- a/test-segs/ts1.mk
+++ b/test-segs/ts1.mk
@@ -1,7 +1,6 @@
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 # For test only.
 #----------------------------------------------------------------------------
-# The prefix $(call Last-Segment-Basename) must be unique for all files.
 # +++++
 $(call Last-Segment-UN)
 ifndef ${LastSegUN}.SegID

--- a/test-segs/ts1.mk
+++ b/test-segs/ts1.mk
@@ -3,8 +3,8 @@
 #----------------------------------------------------------------------------
 # The prefix $(call Last-Segment-Basename) must be unique for all files.
 # +++++
-# Preamble
-ifndef $(call Last-Segment-Basename).SegID
+$(call Last-Segment-UN)
+ifndef ${LastSegUN}.SegID
 $(call Enter-Segment)
 # -----
 

--- a/test-segs/ts2.mk
+++ b/test-segs/ts2.mk
@@ -1,8 +1,6 @@
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 # For test only.
 #----------------------------------------------------------------------------
-# The prefix $(call Last-Segment-Basename) must be unique for all files.
-# +++++
 $(call Last-Segment-UN)
 ifndef ${LastSegUN}.SegID
 $(call Enter-Segment)

--- a/test-segs/ts2.mk
+++ b/test-segs/ts2.mk
@@ -3,8 +3,8 @@
 #----------------------------------------------------------------------------
 # The prefix $(call Last-Segment-Basename) must be unique for all files.
 # +++++
-# Preamble
-ifndef $(call Last-Segment-Basename).SegID
+$(call Last-Segment-UN)
+ifndef ${LastSegUN}.SegID
 $(call Enter-Segment)
 # -----
 

--- a/test-segs/ts2.mk
+++ b/test-segs/ts2.mk
@@ -3,24 +3,26 @@
 #----------------------------------------------------------------------------
 $(call Last-Segment-UN)
 ifndef ${LastSegUN}.SegID
-$(call Enter-Segment)
+$(call Enter-Segment,For test only.)
 # -----
 
-$(call Info,${Seg}:Path:$(call Last-Segment-Path))
+$(call Info,${SegUN}:Path:$(call Last-Segment-Path))
 $(call Expect-Vars,Seg:ts2 ts2Seg:ts2)
 
 # +++++
 # Postamble
-ifneq ($(call Is-Goal,help-${Seg}),)
-$(call test-message,Help message variable: help-${Seg})
-define help-${Seg}
+__h := $(or $(call Is-Goal,help-${SegUN}),$(call Is-Goal,help-${SegID}))
+ifneq (${__h},)
+$(call Attention,Generating help for:${Seg})
+define __help
 Make segment: ${Seg}.mk
 
 This segment is in the helpers directory and is intended for test only.
 
 Command line goals:
-  help-${Seg}   Display this help.
+  help-${SegUN}   Display this help.
 endef
+${__h} := ${__help}
 endif
 $(call Exit-Segment)
 else

--- a/test-segs/ts3.mk
+++ b/test-segs/ts3.mk
@@ -1,7 +1,6 @@
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 # For test only.
 #----------------------------------------------------------------------------
-# The prefix $(call Last-Segment-Basename) must be unique for all files.
 # +++++
 $(call Last-Segment-UN)
 ifndef ${LastSegUN}.SegID

--- a/test-segs/ts3.mk
+++ b/test-segs/ts3.mk
@@ -3,8 +3,8 @@
 #----------------------------------------------------------------------------
 # The prefix $(call Last-Segment-Basename) must be unique for all files.
 # +++++
-# Preamble
-ifndef $(call Last-Segment-Basename).SegID
+$(call Last-Segment-UN)
+ifndef ${LastSegUN}.SegID
 $(call Enter-Segment)
 # -----
 

--- a/test-segs/ts3.mk
+++ b/test-segs/ts3.mk
@@ -4,24 +4,26 @@
 # +++++
 $(call Last-Segment-UN)
 ifndef ${LastSegUN}.SegID
-$(call Enter-Segment)
+$(call Enter-Segment,For test only.)
 # -----
 
-$(call Info,${Seg}:Path:$(call Last-Segment-Path))
+$(call Info,${SegUN}:Path:$(call Last-Segment-Path))
 $(call Expect-Vars,Seg:ts3 ts3Seg:ts3)
 
 # +++++
 # Postamble
-ifneq ($(call Is-Goal,help-${Seg}),)
-$(call test-message,Help message variable: help-${Seg})
-define help-${Seg}
+__h := $(or $(call Is-Goal,help-${SegUN}),$(call Is-Goal,help-${SegID}))
+ifneq (${__h},)
+$(call Attention,Generating help for:${Seg})
+define __help
 Make segment: ${Seg}.mk
 
 This segment is in the helpers directory and is intended for test only.
 
 Command line goals:
-  help-${Seg}   Display this help.
+  help-${SegUN}   Display this help.
 endef
+${__h} := ${__help}
 endif
 $(call Exit-Segment)
 else

--- a/test-suites/expect-tests.mk
+++ b/test-suites/expect-tests.mk
@@ -4,10 +4,10 @@
 # +++++
 $(call Last-Segment-UN)
 ifndef ${LastSegUN}.SegID
-$(call Enter-Segment)
+$(call Enter-Segment,Verify the helper macros for expecting values and results.)
 # -----
 
-$(call Declare-Suite,${Seg},Verify the variable related helper macros.)
+$(call Declare-Suite,${SegUN},Verify the variable related helper macros.)
 
 # Define the tests in the order in which they should be run.
 
@@ -171,8 +171,9 @@ $(call End-Declare-Suite)
 # +++++
 # Postamble
 # Define help only if needed.
-#ifneq ($(call Is-Goal,help-${Seg}),)
-define _help
+__h := $(or $(call Is-Goal,help-${SegUN}),$(call Is-Goal,help-${SegID}))
+ifneq (${__h},)
+define __help
 Make test suite: ${Seg}.mk
 
 This test suite verifies the variety of expect macros.
@@ -181,14 +182,14 @@ Verifies these macros:
 ${help-Expect-Vars}
 
 Command line goals:
-  help-${Seg}
+  help-${SegUN}
     Display this help.
-  show-${Seg}.TestL
+  show-${SegUN}.TestL
     Display the list of tests included in this suite.
 endef
-help-${Seg} := $(call _help)
+help-${SegUN} := $(call _help)
 
-#endif # help goal message.
+endif # help goal message.
 
 $(call Exit-Segment)
 else # <u>SegID exists

--- a/test-suites/expect-tests.mk
+++ b/test-suites/expect-tests.mk
@@ -3,8 +3,8 @@
 #----------------------------------------------------------------------------
 # The prefix $(call Last-Segment-Basename) must be unique for all files.
 # +++++
-# Preamble
-ifndef $(call Last-Segment-Basename).SegID
+$(call Last-Segment-UN)
+ifndef ${LastSegUN}.SegID
 $(call Enter-Segment)
 # -----
 

--- a/test-suites/expect-tests.mk
+++ b/test-suites/expect-tests.mk
@@ -7,7 +7,7 @@ ifndef ${LastSegUN}.SegID
 $(call Enter-Segment,Verify the helper macros for expecting values and results.)
 # -----
 
-$(call Declare-Suite,${SegUN},Verify the variable related helper macros.)
+$(call Declare-Suite,${Seg},Verify the variable related helper macros.)
 
 # Define the tests in the order in which they should be run.
 

--- a/test-suites/expect-tests.mk
+++ b/test-suites/expect-tests.mk
@@ -1,7 +1,6 @@
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 # Verify the helper macros for expecting values and results.
 #----------------------------------------------------------------------------
-# The prefix $(call Last-Segment-Basename) must be unique for all files.
 # +++++
 $(call Last-Segment-UN)
 ifndef ${LastSegUN}.SegID

--- a/test-suites/sticky-tests.mk
+++ b/test-suites/sticky-tests.mk
@@ -1,7 +1,6 @@
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 # Test the macros and variables related to Sticky variables.
 #----------------------------------------------------------------------------
-# The prefix $(call Last-Segment-Basename) must be unique for all files.
 # +++++
 $(call Last-Segment-UN)
 ifndef ${LastSegUN}.SegID

--- a/test-suites/sticky-tests.mk
+++ b/test-suites/sticky-tests.mk
@@ -7,7 +7,7 @@ ifndef ${LastSegUN}.SegID
 $(call Enter-Segment,Test the macros and variables related to Sticky variables.)
 # -----
 
-$(call Declare-Suite,${SegUN},Verify the Sticky variable macros.)
+$(call Declare-Suite,${Seg},Verify the Sticky variable macros.)
 
 ${.SuiteN}.Prereqs :=
 
@@ -222,12 +222,12 @@ define ${.TestUN}
 
   $(call Test-Info,Verify sticky variable has been removed.)
   $(call Expect-Error,Var ${_vn1} has not been defined.)
-  $(call Remove-Sticky,${_vn1},Redefined)
+  $(call Remove-Sticky,${_vn1})
   $(call Verify-No-Error)
 
   $(call Test-Info,Verify sticky variable has been removed.)
   $(call Expect-Error,Var ${_vn1} has not been defined.)
-  $(call Remove-Sticky,${_vn1},Redefined)
+  $(call Remove-Sticky,${_vn1})
   $(call Verify-Error)
 
   $(call End-Test)

--- a/test-suites/sticky-tests.mk
+++ b/test-suites/sticky-tests.mk
@@ -3,8 +3,8 @@
 #----------------------------------------------------------------------------
 # The prefix $(call Last-Segment-Basename) must be unique for all files.
 # +++++
-# Preamble
-ifndef $(call Last-Segment-Basename).SegID
+$(call Last-Segment-UN)
+ifndef ${LastSegUN}.SegID
 $(call Enter-Segment)
 # -----
 

--- a/test-suites/sticky-tests.mk
+++ b/test-suites/sticky-tests.mk
@@ -4,10 +4,10 @@
 # +++++
 $(call Last-Segment-UN)
 ifndef ${LastSegUN}.SegID
-$(call Enter-Segment)
+$(call Enter-Segment,Test the macros and variables related to Sticky variables.)
 # -----
 
-$(call Declare-Suite,${Seg},Verify the Sticky variable macros.)
+$(call Declare-Suite,${SegUN},Verify the Sticky variable macros.)
 
 ${.SuiteN}.Prereqs :=
 
@@ -239,19 +239,20 @@ $(call End-Declare-Suite)
 # +++++
 # Postamble
 # Define help only if needed.
-#ifneq ($(call Is-Goal,help-${Seg}),)
-define help-${Seg}
+__h := $(or $(call Is-Goal,help-${SegUN}),$(call Is-Goal,help-${SegID}))
+ifneq (${__h},)
+define __help
 Make test suite: ${Seg}.mk
 
 Verify the macros and variables used for maintaining sticky variables.
 
 Command line goals:
-  help-${Seg}
+  help-${SegUN}
     Display this help.
-  show-${Seg}.TestL
+  show-${SegUN}.TestL
     Display the list of tests included in this suite.
 endef
-#endif # help goal message.
+endif # help goal message.
 
 $(call Exit-Segment)
 else # <u>SegID exists

--- a/test-suites/var-tests.mk
+++ b/test-suites/var-tests.mk
@@ -1,7 +1,6 @@
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 # Verify the helper macros for manipulating variables.
 #----------------------------------------------------------------------------
-# The prefix $(call Last-Segment-Basename) must be unique for all files.
 # +++++
 $(call Last-Segment-UN)
 ifndef ${LastSegUN}.SegID

--- a/test-suites/var-tests.mk
+++ b/test-suites/var-tests.mk
@@ -4,10 +4,10 @@
 # +++++
 $(call Last-Segment-UN)
 ifndef ${LastSegUN}.SegID
-$(call Enter-Segment)
+$(call Enter-Segment,Verify the helper macros for manipulating variables.)
 # -----
 
-$(call Declare-Suite,${Seg},Verify the variable related helper macros.)
+$(call Declare-Suite,${SegUN},Verify the variable related helper macros.)
 
 # Define the tests in the order in which they should be run.
 
@@ -370,21 +370,22 @@ $(call End-Declare-Suite)
 # +++++
 # Postamble
 # Define help only if needed.
-#ifneq ($(call Is-Goal,help-${Seg}),)
-define _help
+__h := $(or $(call Is-Goal,help-${SegUN}),$(call Is-Goal,help-${SegID}))
+ifneq (${__h},)
+define __help
 Make test suite: ${Seg}.mk
 
 <make test suite help messages>
 
 Command line goals:
-  help-${Seg}
+  help-${SegUN}
     Display this help.
-  show-${Seg}.TestL
+  show-${SegUN}.TestL
     Display the list of tests included in this suite.
 endef
-help-${Seg} := $(call _help)
+help-${SegUN} := $(call _help)
 
-#endif # help goal message.
+endif # help goal message.
 
 $(call Exit-Segment)
 else # <u>SegID exists

--- a/test-suites/var-tests.mk
+++ b/test-suites/var-tests.mk
@@ -7,7 +7,7 @@ ifndef ${LastSegUN}.SegID
 $(call Enter-Segment,Verify the helper macros for manipulating variables.)
 # -----
 
-$(call Declare-Suite,${SegUN},Verify the variable related helper macros.)
+$(call Declare-Suite,${Seg},Verify the variable related helper macros.)
 
 # Define the tests in the order in which they should be run.
 

--- a/test-suites/var-tests.mk
+++ b/test-suites/var-tests.mk
@@ -3,8 +3,8 @@
 #----------------------------------------------------------------------------
 # The prefix $(call Last-Segment-Basename) must be unique for all files.
 # +++++
-# Preamble
-ifndef $(call Last-Segment-Basename).SegID
+$(call Last-Segment-UN)
+ifndef ${LastSegUN}.SegID
 $(call Enter-Segment)
 # -----
 


### PR DESCRIPTION
This iteration adds pseudo unique names for segments which helps avoid naming conflicts for segments of the same name but having different paths. See help-helpers for more information.
The prefix used to indicate non-global variables was changed from a single underscore to a double underscore. This should help avoid confusion with files which use the helpers.
In the process several other problems were discovered and corrected.