### PR TITLE
Dev - Test suite update to display help for all declared tests.

### DIFF
--- a/helpers.mk
+++ b/helpers.mk
@@ -1817,7 +1817,11 @@ help: help-1
 origin-%:
 > @echo 'Origin:$*=$(origin $*)'
 
-__h := $(or $(call Is-Goal,help-${SegUN}),$(call Is-Goal,help-${SegID}))
+__h := \
+  $(or \
+    $(call Is-Goal,help-${Seg}),\
+    $(call Is-Goal,help-${SegUN}),\
+    $(call Is-Goal,help-${SegID}))
 ifneq (${__h},)
 define __help
 Make segment: ${Seg}.mk

--- a/helpers.mk
+++ b/helpers.mk
@@ -762,6 +762,7 @@ ${_macro}
     1 = The path for the UN.
     2 = The variable in which to store the UN.
 endef
+help-${_macro} := $(call _help)
 define ${_macro}
   $(eval __pw := $(subst /, ,$(realpath $(1))))
   $(eval __i := $(words ${__pw}))

--- a/suite-template.mk
+++ b/suite-template.mk
@@ -16,7 +16,7 @@ ${.SuiteN}.Prereqs :=
 $(call Declare-Test,<test>)
 define _help
 ${.TestUN}
-  Verify the macro:${.TestUN}
+  Verify the macro:$(call Get-Test-Name,${.TestUN})
 endef
 help-${.TestUN} := $(call _help)
 ${.TestUN}.Prereqs :=
@@ -30,26 +30,32 @@ define ${.TestUN}
   $(call Exit-Macro)
 endef
 
-$(call End-Declare-Suite)
-
 # +++++
 # Postamble
 # Define help only if needed.
-__h := $(or $(call Is-Goal,help-${SegUN}),$(call Is-Goal,help-${SegID}))
+__h := \
+  $(or \
+    $(call Is-Goal,help-${Seg}),\
+    $(call Is-Goal,help-${SegUN}),\
+    $(call Is-Goal,help-${SegID}))
 ifneq (${__h},)
 define __help
 Make test suite: ${Seg}.mk
 
 <make test suite help messages>
 
+Tests:
+$(foreach __t,${${.SuiteN}.TestL},
+${help-${__t}})
+
 Command line goals:
-  help-${SegUN}
+  help-${Seg} or help-${SegUN} or help-${SegID}
     Display this help.
-  show-${SegUN}.TestL
-    Display the list of tests included in this suite.
 endef
 ${__h} := ${__help}
 endif # help goal message.
+
+$(call End-Declare-Suite)
 
 $(call Exit-Segment)
 else # <u>SegID exists

--- a/test-helpers.mk
+++ b/test-helpers.mk
@@ -1263,7 +1263,11 @@ test:
 
 # +++++
 # Postamble
-__h := $(or $(call Is-Goal,help-${SegUN}),$(call Is-Goal,help-${SegID}))
+__h := \
+  $(or \
+    $(call Is-Goal,help-${Seg}),\
+    $(call Is-Goal,help-${SegUN}),\
+    $(call Is-Goal,help-${SegID}))
 ifneq (${__h},)
 $(call Attention,Generating help for:${Seg})
 define __help

--- a/test-suites/expect-tests.mk
+++ b/test-suites/expect-tests.mk
@@ -166,30 +166,32 @@ define ${.TestUN}
   $(call Exit-Macro)
 endef
 
-$(call End-Declare-Suite)
-
 # +++++
 # Postamble
 # Define help only if needed.
-__h := $(or $(call Is-Goal,help-${SegUN}),$(call Is-Goal,help-${SegID}))
+__h := \
+  $(or \
+    $(call Is-Goal,help-${Seg}),\
+    $(call Is-Goal,help-${SegUN}),\
+    $(call Is-Goal,help-${SegID}))
 ifneq (${__h},)
 define __help
 Make test suite: ${Seg}.mk
 
 This test suite verifies the variety of expect macros.
 
-Verifies these macros:
-${help-Expect-Vars}
+Tests:
+$(foreach __t,${${.SuiteN}.TestL},
+${help-${__t}})
 
 Command line goals:
   help-${SegUN}
     Display this help.
-  show-${SegUN}.TestL
-    Display the list of tests included in this suite.
 endef
-help-${SegUN} := $(call _help)
-
+${__h} := ${__help}
 endif # help goal message.
+
+$(call End-Declare-Suite)
 
 $(call Exit-Segment)
 else # <u>SegID exists

--- a/test-suites/sticky-tests.mk
+++ b/test-suites/sticky-tests.mk
@@ -16,7 +16,7 @@ ${.SuiteN}.Prereqs :=
 $(call Declare-Test,Sticky)
 define _help
 ${.TestUN}
-  Verify the macro:${.TestUN}
+  Verify the macro:$(call Get-Test-Name,${.TestUN})
   This verifies the logic of sticky variables (see help-Sticky).
   Two sticky variables, CASES and SUITES_PATH, should already exist by the time
   this macro is called. These are first verified to have correct values.
@@ -145,8 +145,7 @@ endef
 $(call Declare-Test,Redefine-Sticky)
 define _help
 ${.TestUN}
-  Verify the macro:${.TestUN}
-
+  Verify the macro:$(call Get-Test-Name,${.TestUN})
 endef
 help-${.TestUN} := $(call _help)
 ${.TestUN}.Prereqs := ${.SuiteN}.Sticky test-vars.Compare-Strings
@@ -204,8 +203,7 @@ endef
 $(call Declare-Test,Remove-Sticky)
 define _help
 ${.TestUN}
-  Verify the macro:${.TestUN}
-
+  Verify the macro:$(call Get-Test-Name,${.TestUN})
 endef
 help-${.TestUN} := $(call _help)
 ${.TestUN}.Prereqs := ${.SuiteN}.Redefine-Sticky
@@ -234,25 +232,32 @@ define ${.TestUN}
   $(call Exit-Macro)
 endef
 
-$(call End-Declare-Suite)
-
 # +++++
 # Postamble
 # Define help only if needed.
-__h := $(or $(call Is-Goal,help-${SegUN}),$(call Is-Goal,help-${SegID}))
+__h := \
+  $(or \
+    $(call Is-Goal,help-${Seg}),\
+    $(call Is-Goal,help-${SegUN}),\
+    $(call Is-Goal,help-${SegID}))
 ifneq (${__h},)
 define __help
 Make test suite: ${Seg}.mk
 
 Verify the macros and variables used for maintaining sticky variables.
 
+Tests:
+$(foreach __t,${${.SuiteN}.TestL},
+${help-${__t}})
+
 Command line goals:
   help-${SegUN}
     Display this help.
-  show-${SegUN}.TestL
-    Display the list of tests included in this suite.
 endef
+${__h} := ${__help}
 endif # help goal message.
+
+$(call End-Declare-Suite)
 
 $(call Exit-Segment)
 else # <u>SegID exists

--- a/test-suites/var-tests.mk
+++ b/test-suites/var-tests.mk
@@ -14,7 +14,7 @@ $(call Declare-Suite,${Seg},Verify the variable related helper macros.)
 $(call Declare-Test,Inc-Var)
 define _help
 ${.TestUN}
-  Verify the helper macro:${.TestUN}
+  Verify the helper macro:$(call Get-Test-Name,${.TestUN})
 endef
 help-${.TestUN} := $(call _help)
 ${.TestUN}.Prereqs := expect-tests.Expect-Vars
@@ -35,7 +35,7 @@ endef
 $(call Declare-Test,Dec-Var)
 define _help
 ${.TestUN}
-  Verify the helper macro:${.TestUN}
+  Verify the helper macro:$(call Get-Test-Name,${.TestUN})
 endef
 help-${.TestUN} := $(call _help)
 ${.TestUN}.Prereqs := expect-tests.Expect-Vars
@@ -56,7 +56,7 @@ endef
 $(call Declare-Test,Add-Var)
 define _help
 ${.TestUN}
-  Verify the helper macro:${.TestUN}
+  Verify the helper macro:$(call Get-Test-Name,${.TestUN})
 endef
 help-${.TestUN} := $(call _help)
 ${.TestUN}.Prereqs := expect-tests.Expect-Vars
@@ -95,7 +95,7 @@ endef
 $(call Declare-Test,Sub-Var)
 define _help
 ${.TestUN}
-  Verify the helper macro:${.TestUN}
+  Verify the helper macro:$(call Get-Test-Name,${.TestUN})
 endef
 help-${.TestUN} := $(call _help)
 ${.TestUN}.Prereqs := expect-tests.Expect-Vars
@@ -134,7 +134,7 @@ endef
 $(call Declare-Test,To-Shell-Var)
 define _help
 ${.TestUN}
-  Verify the helper macro:${.TestUN}
+  Verify the helper macro:$(call Get-Test-Name,${.TestUN})
 endef
 help-${.TestUN} := $(call _help)
 ${.TestUN}.Prereqs := expect-tests.Expect-Vars
@@ -152,7 +152,7 @@ endef
 $(call Declare-Test,To-Lower)
 define _help
 ${.TestUN}
-  Verify the helper macro:${.TestUN}
+  Verify the helper macro:$(call Get-Test-Name,${.TestUN})
 endef
 help-${.TestUN} := $(call _help)
 ${.TestUN}.Prereqs := expect-tests.Expect-Vars
@@ -173,7 +173,7 @@ endef
 $(call Declare-Test,To-Upper)
 define _help
 ${.TestUN}
-  Verify the helper macro:${.TestUN}
+  Verify the helper macro:$(call Get-Test-Name,${.TestUN})
 endef
 help-${.TestUN} := $(call _help)
 ${.TestUN}.Prereqs := expect-tests.Expect-Vars
@@ -198,7 +198,7 @@ endef
 $(call Declare-Test,Require)
 define _help
 ${.TestUN}
-  Verify the helper macro:${.TestUN}
+  Verify the helper macro:$(call Get-Test-Name,${.TestUN})
 endef
 help-${.TestUN} := $(call _help)
 ${.TestUN}.Prereqs := expect-tests.Expect-List
@@ -247,7 +247,7 @@ endef
 $(call Declare-Test,Compare-Strings)
 define _help
 ${.TestUN}
-  Verify the helper macro:${.TestUN}
+  Verify the helper macro:$(call Get-Test-Name,${.TestUN})
 endef
 help-${.TestUN} := $(call _help)
 ${.TestUN}.Prereqs :=
@@ -365,27 +365,32 @@ define ${.TestUN}
   $(call Exit-Macro)
 endef
 
-$(call End-Declare-Suite)
-
 # +++++
 # Postamble
 # Define help only if needed.
-__h := $(or $(call Is-Goal,help-${SegUN}),$(call Is-Goal,help-${SegID}))
+__h := \
+  $(or \
+    $(call Is-Goal,help-${Seg}),\
+    $(call Is-Goal,help-${SegUN}),\
+    $(call Is-Goal,help-${SegID}))
 ifneq (${__h},)
 define __help
 Make test suite: ${Seg}.mk
 
-<make test suite help messages>
+A series of tests to verify the helpers variable related macros.
+
+Tests:
+$(foreach __t,${${.SuiteN}.TestL},
+${help-${__t}})
 
 Command line goals:
-  help-${SegUN}
+  help-${Seg} or help-${SegUN} or help-${SegID}
     Display this help.
-  show-${SegUN}.TestL
-    Display the list of tests included in this suite.
 endef
-help-${SegUN} := $(call _help)
-
+${__h} := ${__help}
 endif # help goal message.
+
+$(call End-Declare-Suite)
 
 $(call Exit-Segment)
 else # <u>SegID exists


### PR DESCRIPTION
The test suites have been updated to display the help for all tests.
Also changed the help detection to include the segment name which will work as expected when there are no name conflicts. When a name conflict does occur the help for the segment will be for the last segment having the same name in which case the segment ID or segment unique name can be used to display help for the correct segment.