### PR TITLE
Dev - Help list generation and display.

### DIFF
--- a/helpers.mk
+++ b/helpers.mk
@@ -1804,10 +1804,11 @@ call-%:
 
 help-%:
 > $(file >${TmpPath}/help-$*,${help-$*})
-> $(if ${$*.MoreHelpList},\
-    $(foreach _h,${$*.MoreHelpList},\
-      $(file >>${TmpPath}/help-$*,==== ${__h} ====)\
-      $(file >>${TmpPath}/help-$*,${${__h}})))
+> $(if $(findstring undefined,$(flavor $*.MoreHelpList)),,\
+    $(if ${$*.MoreHelpList},\
+      $(foreach _h,${$*.MoreHelpList},\
+        $(file >>${TmpPath}/help-$*,==== ${__h} ====)\
+        $(file >>${TmpPath}/help-$*,${${__h}}))))
 > less ${TmpPath}/help-$*
 > rm ${TmpPath}/help-$*
 

--- a/helpers.mk
+++ b/helpers.mk
@@ -1725,7 +1725,7 @@ define ${_macro}
     $(foreach __s,${SegUNs},
       $(call Info,${${__s}.SegID}:${${__s}.Seg}:${${__s}.SegUN}:${${__s}.SegD})
     )
-  $(call Exist-Macro)
+  $(call Exit-Macro)
 endef
 
 _macro := More-Help

--- a/helpers.mk
+++ b/helpers.mk
@@ -1732,13 +1732,13 @@ define ${_macro}
   $(call Enter-Macro,$(0),$(1))
   $(if $(1),
     $(call Debug,Help list for:$(1):${$(1)})
-    $(eval $(1)_MoreHelpList := )
+    $(eval $(1).MoreHelpList := )
     $(foreach __sym,${$(1)},
       $(call Debug,Adding help for:${__sym})
       $(if $(filter $(origin help-${__sym}),undefined),
         $(call Warn,Undefined help message: help-${__sym})
       ,
-        $(eval $(1)_MoreHelpList += help-${__sym})
+        $(eval $(1).MoreHelpList += help-${__sym})
       )
     )
   ,
@@ -1804,8 +1804,8 @@ call-%:
 
 help-%:
 > $(file >${TmpPath}/help-$*,${help-$*})
-> $(if ${$*_MoreHelpList},\
-    $(foreach _h,${$*_MoreHelpList},\
+> $(if ${$*.MoreHelpList},\
+    $(foreach _h,${$*.MoreHelpList},\
       $(file >>${TmpPath}/help-$*,==== ${__h} ====)\
       $(file >>${TmpPath}/help-$*,${${__h}})))
 > less ${TmpPath}/help-$*

--- a/helpers.mk
+++ b/helpers.mk
@@ -830,12 +830,12 @@ define ${_macro}
   $(call Log-Message,ERR!,$(1))
   $(eval Errors = yes)
   $(warning Error:${SegUN}:$(1))
-  $(call Debug,Handler: ${Error_Callback} Safe:${Error_Safe})
+  $(call Verbose,Handler: ${Error_Callback} Safe:${Error_Safe})
   $(if ${Error_Callback},
     $(if ${Error_Safe},
       $(eval Error_Safe := )
-      $(call Debug,Calling ${Error_Callback}.)
-      $(call Debug,Message:$(1).)
+      $(call Verbose,Calling ${Error_Callback}.)
+      $(call Verbose,Message:$(1).)
       $(call ${Error_Callback},$(1))
       $(eval Error_Safe := 1)
     ,
@@ -966,10 +966,10 @@ $(call Add-Help,${_macro})
 define ${_macro}
 $(strip \
   $(call Enter-Macro,$(0),$(1))
-  $(call Debug,Requiring defined variables:$(1))
+  $(call Verbose,Requiring defined variables:$(1))
   $(eval __r :=)
   $(foreach __v,$(1),
-    $(call Debug,Requiring: ${__v})
+    $(call Verbose,Requiring: ${__v})
     $(if $(call Is-Not-Defined,${__v}),
       $(eval __r += ${__v})
       $(call Signal-Error,${Caller} requires variable ${__v} must be defined.)
@@ -982,7 +982,7 @@ endef
 
 define __mbof
   $(if $(filter ${$(1)},$(2)),
-    $(call Debug,$(1)=${$(1)} and is a valid option) 1
+    $(call Verbose,$(1)=${$(1)} and is a valid option) 1
   ,
     $(call Signal-Error,Variable $(1)=${$(1)} must equal one of: $(2))
   )
@@ -1032,7 +1032,7 @@ define ${_macro}
     $(if $(call Is-Not-Defined,$(1)),
       $(eval $(1) := $(2))
     ,
-      $(call Debug,Var $(1) has override value: ${$(1)})
+      $(call Verbose,Var $(1) has override value: ${$(1)})
     )
   )
   $(call Exit-Macro)
@@ -1065,15 +1065,15 @@ define ${_macro}
       $(call Checking words at:${__i})
       $(if $(filter ${__w},$(word ${__i},${$(2)})),
       ,
-        $(call Debug,Difference found.)
+        $(call Verbose,Difference found.)
         $(eval $(3) += ${__i})
       )
     )
   ,
-    $(call Debug,String lengths differ by ${__d} words.)
+    $(call Verbose,String lengths differ by ${__d} words.)
     $(eval $(3) := d ${__d})
   )
-  $(call Debug,Returning:${$(3)})
+  $(call Verbose,Returning:${$(3)})
   $(call Exit-Macro)
 endef
 
@@ -1128,14 +1128,14 @@ endef
 help-${_macro} := $(call _help)
 $(call Add-Help,${_macro})
 define ${_macro}
-  $(call Debug,MAKEFILE_LIST:${MAKEFILE_LIST})
-  $(call Debug,path:$(realpath $(1)))
+  $(call Verbose,MAKEFILE_LIST:${MAKEFILE_LIST})
+  $(call Verbose,path:$(realpath $(1)))
   $(eval __seg := $(basename $(notdir $(1))))
-  $(call Debug,__seg:${__seg})
+  $(call Verbose,__seg:${__seg})
   $(eval __p := $(subst /.,,$(dir $(realpath $(1))).))
-  $(call Debug,__p:${__p})
+  $(call Verbose,__p:${__p})
   $(eval $(2) := $(lastword $(subst /, ,${__p}.$(strip ${__seg}))))
-  $(call Debug,$(2):${$(2)})
+  $(call Verbose,$(2):${$(2)})
 endef
 
 _macro := Last-Segment-UN
@@ -1151,7 +1151,7 @@ $(call Add-Help,${_macro})
 define ${_macro}
   $(call Enter-Macro,$(0))
   $(call Path-To-UN,$(lastword ${MAKEFILE_LIST}),LastSegUN)
-  $(call Debug,Path-To-UN returned:${LastSegUN})
+  $(call Verbose,Path-To-UN returned:${LastSegUN})
   $(call Exit-Macro)
 endef
 
@@ -1330,16 +1330,16 @@ $(call Add-Help,${_macro})
 define ${_macro}
   $(call Enter-Macro,$(0),$(1) $(2))
   $(eval $(2) := )
-  $(call Debug,Locating segment: $(1))
-  $(call Debug,Segment paths:${SegPaths} $(call Get-Segment-Path,${SegID}))
+  $(call Verbose,Locating segment: $(1))
+  $(call Verbose,Segment paths:${SegPaths} $(call Get-Segment-Path,${SegID}))
   $(foreach __p,${SegPaths} $(call Get-Segment-Path,${SegID}),
-    $(call Debug,Trying: ${__p})
+    $(call Verbose,Trying: ${__p})
     $(if $(wildcard ${__p}/$(1).mk),
       $(eval $(2) := ${__p}/$(1).mk)
     )
   )
   $(if ${$(2)},
-    $(call Debug,Found segment:${$(2)})
+    $(call Verbose,Found segment:${$(2)})
   ,
     $(call Signal-Error,$(1).mk not found.)
   )
@@ -1385,14 +1385,14 @@ $(call Add-Help,${_macro})
 define ${_macro}
   $(call Enter-Macro,$(0),$(1))
   $(if $(findstring .mk,$(1)),
-    $(call Debug,Including segment:${1})
+    $(call Verbose,Including segment:${1})
     $(eval include $(1))
   ,
     $(if ${$(1).SegID},
-      $(call Debug,Segment $(1) is already loaded.)
+      $(call Verbose,Segment $(1) is already loaded.)
     ,
       $(call Find-Segment,$(1),__seg)
-      $(call Debug,Using segment:${__seg})
+      $(call Verbose,Using segment:${__seg})
       $(eval include ${__seg})
     )
   )
@@ -1493,10 +1493,10 @@ define ${_macro}
   $(eval ${LastSegUN}.SegF := $(call Last-Segment-File))
   $(eval ${LastSegUN}.SegV := $(call To-Shell-Var,${LastSegUN}))
   $(eval ${LastSegUN}.SegD := $(strip $(1)))
-  $(eval $(call Debug,\
+  $(eval $(call Verbose,\
     Entering segment: $(call Get-Segment-Basename,${${LastSegUN}.SegID})))
-  $(call Debug,${LastSegUN}.SegID:${${LastSegUN}.SegID})
-  $(call Debug,Setting context:${${LastSegUN}.SegID})
+  $(call Verbose,${LastSegUN}.SegID:${${LastSegUN}.SegID})
+  $(call Verbose,Setting context:${${LastSegUN}.SegID})
   $(call __Push-SegID)
   $(call Set-Segment-Context,${${LastSegUN}.SegID})
   $(call Exit-Macro)
@@ -1513,7 +1513,7 @@ help-${_macro} := $(call _help)
 $(call Add-Help,${_macro})
 define ${_macro}
   $(call Enter-Macro,$(0))
-  $(call Debug,Exiting segment: ${${SegUN}.Seg})
+  $(call Verbose,Exiting segment: ${${SegUN}.Seg})
   $(call __Pop-SegID)
   $(eval $(call Set-Segment-Context,${__PrvSegID}))
   $(call Exit-Macro)
@@ -1531,7 +1531,7 @@ help-${_macro} := $(call _help)
 $(call Add-Help,${_macro})
 define ${_macro}
   $(call Enter-Macro,$(0))
-  $(call Debug,\
+  $(call Verbose,\
     Segment exists: ID = ${${LastSegUN}.SegID}: file = $(call Get-Segment-File,${${LastSegUN}.SegID}))
   $(if \
     $(findstring \
@@ -1668,11 +1668,11 @@ help-${_macro} := $(call _help)
 $(call Add-Help,${_macro})
 define ${_macro}
   $(call Enter-Macro,$(0))
-  $(call Debug,Resolving help goals.)
-  $(call Debug,Help goals: $(filter help%,${Goals}))
+  $(call Verbose,Resolving help goals.)
+  $(call Verbose,Help goals: $(filter help%,${Goals}))
   $(foreach __s,$(patsubst help-%,%,$(filter help-%,${Goals})),
     $(if $(call Is-Not-Defined,help-${__s}),
-      $(call Debug,Resolving help for help-${__s})
+      $(call Verbose,Resolving help for help-${__s})
       $(if $(filter \
         ${__s},2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20),
         $(eval help-${__s} := \
@@ -1685,7 +1685,7 @@ define ${_macro}
         )
       )
     ,
-      $(call Debug,Help help-${__s} is defined.)
+      $(call Verbose,Help help-${__s} is defined.)
     )
   )
   $(call Exit-Macro)
@@ -1718,10 +1718,10 @@ help-${_macro} := $(call _help)
 $(call Add-Help,${_macro})
 define ${_macro}
   $(call Enter-Macro,$(0),$(1) $(2) $(3))
-  $(call Debug,Adding $(3) to $(1))
-  $(call Debug,Var: $(2))
+  $(call Verbose,Adding $(3) to $(1))
+  $(call Verbose,Var: $(2))
   $(eval $(2) = $(3))
-  $(call Debug,$(2)=$(3))
+  $(call Verbose,$(2)=$(3))
   $(eval $(1) += $(3))
   $(call Exit-Macro)
 endef
@@ -1833,14 +1833,14 @@ help-${_macro} := $(call _help)
 $(call Add-Help,${_macro})
 define ${_macro}
   $(call Enter-Macro,$(0),$(1) $(2))
-  $(call Debug,Command:$(1))
+  $(call Verbose,Command:$(1))
   $(eval Run_Output := $(shell $(1) 2>&1;echo $$?))
-  $(call Debug,Run_Output = ${Run_Output})
+  $(call Verbose,Run_Output = ${Run_Output})
   $(eval Run_Rc := $(call Return-Code,${Run_Output}))
   $(if ${Run_Rc},
     $(call Warn,Shell return code:${Run_Rc})
   )
-  $(call Debug,Run_Rc = ${Run_Rc})
+  $(call Verbose,Run_Rc = ${Run_Rc})
   $(call Exit-Macro)
 endef
 
@@ -1886,19 +1886,19 @@ endef
 
 # Set SegID to the segment that included helpers so that the previous segment
 # set by Enter-Segment and used by Exit-Segment will have a valid value.
-$(call Debug,MAKEFILE_LIST:${MAKEFILE_LIST})
-$(call Debug,$(realpath $(firstword ${MAKEFILE_LIST})))
-$(call Debug,__i:$(call Last-Segment-ID))
+$(call Verbose,MAKEFILE_LIST:${MAKEFILE_LIST})
+$(call Verbose,$(realpath $(firstword ${MAKEFILE_LIST})))
+$(call Verbose,__i:$(call Last-Segment-ID))
 # Initialize the top level context.
 $(call __Init-Segment-Context,${MakeD})
 
-$(call Debug,Helpers Seg:${Seg})
-$(call Debug,Helpers UN:${SegUN})
-$(call Debug,Included from:$(realpath $(firstword ${MAKEFILE_LIST})))
-$(call Debug,SegUNs:${SegUNs})
+$(call Verbose,Helpers Seg:${Seg})
+$(call Verbose,Helpers UN:${SegUN})
+$(call Verbose,Included from:$(realpath $(firstword ${MAKEFILE_LIST})))
+$(call Verbose,SegUNs:${SegUNs})
 
 $(call Enter-Segment,Helper macros for makefiles.)
-$(call Debug,In segment:${SegUN})
+$(call Verbose,In segment:${SegUN})
 
 # These are helper functions for shell scripts (Bash).
 $(call Add-Help-Section,ShellHelpers,Helper functions for shell scripts .)
@@ -2020,7 +2020,7 @@ define ${_macro}
   $(call Enter-Macro,$(0),$(1) $(2))
   $(eval __snl := $(subst =,${Space},$(1)))
   $(eval __sn := $(word 1,${__snl}))
-  $(call Debug,Sticky:Var:${__sn})
+  $(call Verbose,Sticky:Var:${__sn})
 
   $(if $(call Is-Sticky-Var,${__sn}),
     $(call Warn,Redefinition of sticky variable ${__sn} ignored.)
@@ -2031,48 +2031,48 @@ define ${_macro}
     ,
       $(shell mkdir -p ${STICKY_PATH})
     )
-    $(call Debug,Flavor of ${__sn} is:$(flavor ${__sn}))
+    $(call Verbose,Flavor of ${__sn} is:$(flavor ${__sn}))
     $(eval __save :=)
     $(if $(call Is-Not-Defined,${__sn}),
-      $(call Debug,Defining ${__sn})
+      $(call Verbose,Defining ${__sn})
       $(if $(findstring =,$(1)),
         $(eval __sv := $(wordlist 2,$(words ${__snl}),${__snl}))
         $(eval __save := 1)
-        $(call Debug,Setting ${__sn} to:"${__sv}".)
+        $(call Verbose,Setting ${__sn} to:"${__sv}".)
       ,
         $(if $(call Is-Sticky,${__sn}),
-          $(call Debug,Reading previously saved value for ${__sn})
+          $(call Verbose,Reading previously saved value for ${__sn})
           $(eval __sv := $(file <${__sf}))
         ,
           $(if $(2),
             $(eval __sv := $(2))
-            $(call Debug,Setting ${__sn} to default:"${__sv}")
+            $(call Verbose,Setting ${__sn} to default:"${__sv}")
             $(eval __save := 1)
           )
         )
       )
       $(eval ${__sn} := ${__sv})
       $(if ${SubMake},
-        $(call Debug,Variables are read-only in a sub-make.)
+        $(call Verbose,Variables are read-only in a sub-make.)
       ,
         $(if ${__save},
-          $(call Debug,Creating sticky:${__sn})
+          $(call Verbose,Creating sticky:${__sn})
           $(file >${__sf},${__sv})
         )
       )
     ,
-      $(call Debug,${__sn} is defined.)
+      $(call Verbose,${__sn} is defined.)
       $(if $(findstring =,$(1)),
         $(eval ${__sn} := $(wordlist 2,$(words ${__snl}),${__snl}))
       )
-      $(call Debug,Saving sticky:${__sn}=${${__sn}})
+      $(call Verbose,Saving sticky:${__sn}=${${__sn}})
       $(if ${SubMake},
-        $(call Debug,Variables are read-only in a sub-make.)
+        $(call Verbose,Variables are read-only in a sub-make.)
       ,
         $(if $(call Is-Sticky,${__sn}),
-          $(call Debug,Replacing sticky:${__sf})
+          $(call Verbose,Replacing sticky:${__sf})
         ,
-          $(call Debug,Creating sticky:${__sf})
+          $(call Verbose,Creating sticky:${__sf})
         )
         $(file >${__sf},${${__sn}})
       )
@@ -2113,17 +2113,17 @@ define ${_macro}
   $(if $(call Is-Sticky-Var,${__rsp}),
     $(eval __rscv := ${${__rsp}})
     $(call Compare-Strings,__rsv,__rscv,__diff)
-    $(call Debug,Old and new diff:${__diff})
+    $(call Verbose,Old and new diff:${__diff})
     $(if ${__diff},
-      $(call Debug,Redefining:${__rsp})
-      $(call Debug,SubMake:${SubMake})
+      $(call Verbose,Redefining:${__rsp})
+      $(call Verbose,SubMake:${SubMake})
       $(if ${SubMake},
         $(call Warn,Cannot overwrite ${__rsp} in a submake.)
       ,
         $(file >$(STICKY_PATH)/${__rsp},${__rsv})
       )
     ,
-      $(call Debug,Var ${__rsp} is unchanged:"${__rsv}" "${__rscv}")
+      $(call Verbose,Var ${__rsp} is unchanged:"${__rsv}" "${__rscv}")
     )
   ,
     $(call Signal-Error,Var ${__rsp} has not been defined.)
@@ -2143,7 +2143,7 @@ $(call Add-Help,${_macro})
 define ${_macro}
   $(call Enter-Macro,$(0),$(1))
   $(if $(call Is-Sticky-Var,$(1)),
-    $(call Debug,Undefining sticky variable: $(1))
+    $(call Verbose,Undefining sticky variable: $(1))
     $(eval StickyVars := $(filter-out $(1),${StickyVars}))
     $(eval undefine $(1))
   ,
@@ -2166,7 +2166,7 @@ define ${_macro}
   $(call Enter-Macro,$(0),$(1))
   $(if $(call Is-Sticky-Var,$(1)),
     $(call Undefine-Sticky,$(1))
-    $(call Debug,Removing sticky variable: $(1))
+    $(call Verbose,Removing sticky variable: $(1))
     $(shell rm ${STICKY_PATH}/$(1))
   ,
     $(call Signal-Error,Var $(1) has not been defined.)\
@@ -2215,10 +2215,10 @@ $(call Add-Help,${_macro})
 define ${_macro}
   $(call Enter-Macro,$(0),$(1))
   $(if $(1),
-    $(call Debug,Help list for:$(1):${$(1)})
+    $(call Verbose,Help list for:$(1):${$(1)})
     $(eval $(1).MoreHelpList := )
     $(foreach __sym,${$(1)},
-      $(call Debug,Adding help for:${__sym})
+      $(call Verbose,Adding help for:${__sym})
       $(if $(call Is-Not-Defined,help-${__sym}),
         $(call Warn,Undefined help message: help-${__sym})
       ,
@@ -2253,8 +2253,8 @@ else
 endif
 $(call Info,Running on: ${Platform})
 
-$(call Debug,MAKELEVEL = ${MAKELEVEL})
-$(call Debug,MAKEFLAGS = ${MAKEFLAGS})
+$(call Verbose,MAKELEVEL = ${MAKELEVEL})
+$(call Verbose,MAKEFLAGS = ${MAKEFLAGS})
 
 ifneq (${LOG_FILE},)
 display-messages: ${LogFile}
@@ -2276,7 +2276,7 @@ define _Call-Macro
 $(eval __w := $(subst :, ,$(2)))
 $(foreach pn,1 2 3,
   $(eval p${pn} := $(subst +, ,$(word ${pn},${__w})))
-  $(call Debug,p${pn}:${p${pn}})
+  $(call Verbose,p${pn}:${p${pn}})
 )
 $(call $(1),${p1},${p2},${p3})
 endef
@@ -2355,8 +2355,8 @@ display-errors
 endef
 ${__h} := ${__help}
 endif # help goal
-$(call Debug,Last-Segment-ID:$(call Last-Segment-ID))
-$(call Debug,${helpers.Seg}.SegID:${${helpers.Seg}.SegID})
+$(call Verbose,Last-Segment-ID:$(call Last-Segment-ID))
+$(call Verbose,${helpers.Seg}.SegID:${${helpers.Seg}.SegID})
 $(call Exit-Segment)
 else # Already loaded.
 $(call Check-Segment-Conflicts)

--- a/helpers.mk
+++ b/helpers.mk
@@ -1187,6 +1187,8 @@ $$(call Exit-Macro)
 $.endef
 
 $$(call Info,New segment: Add variables, macros, goals, and recipes here.)
+# Remove the following line after completing this segment.
+$$(call Signal-Error,This segment has not yet been completed.)
 
 # The command line goal for the segment.
 $${LastSegUN}: $${SegF}

--- a/helpers.mk
+++ b/helpers.mk
@@ -2,6 +2,40 @@
 # Helper macros for makefiles.
 #----------------------------------------------------------------------------
 ifndef helpers.SegID
+SegID := $(words ${MAKEFILE_LIST})
+helpers.SegID := ${SegID}
+$(info helpers.SegID:${helpers.SegID})
+
+_macro := Declare-Help
+define _help
+${_macro}
+  Declare a help message and add it to the help list for the current context
+  identified by SegID (see help-SegAttributes).
+  Parameters:
+    1 = The name of the variable or macro to declare help for.
+endef
+${SegID}.HelpL :=
+define ${_macro}
+  $(eval ${SegID}.HelpL += $(1))
+endef
+help-${_macro} := $(call _help)
+$(call Declare-Help,${_macro})
+
+_macro := Display-Help-List
+define _help
+${_macro}
+  This macro can be called from a segment help to display the accumulated list
+  of help messages.
+  Parameters:
+    1 = The segment ID for which to display the help list.
+endef
+help-${_macro} := $(call _help)
+$(call Declare-Help,${_macro})
+define ${_macro}
+$(foreach _h,${$(1).HelpL},
+
+${help-${_h}})
+endef
 
 # Changing the prefix because some editors, like vscode, don't handle tabs
 # in make files very well. This also slightly improves readability.
@@ -737,8 +771,10 @@ _var := SegAttributes
 ${_var} := SegUN SegID Seg SegP SegF SegV SegD
 define _help
 ${_var} = ${${_var}}
-  Each makefile segment is managed using a set of attributes.
-    <segun>.SegUN
+  Each makefile segment is managed using a set of attributes. The context for
+  a given segment is prefixed by its unique name <segun>. The current context
+  has no prefix.
+    SegUN or <segun>.SegUN
       The pseudo unique name for the segment <segun>. This is then used as the
       key to access the attributes for a given segment.
       This name is a combination of the directory containing the segment and the
@@ -747,19 +783,19 @@ ${_var} = ${${_var}}
       For example:
         If the path is: /dir1/dir2/dir3/seg.mk
         The resulting pseudo unique name is: dir2.dir3
-    <segun>.SegID
+    SegID or <segun>.SegID
       The ID for the segment. This is basically the index in MAKEFILE_LIST for
       the segment.
-    <segun>.Seg
+    Seg or <segun>.Seg
       The segment name.
-    <segun>.SegV
+    SegV or <segun>.SegV
       The name of the segment converted to a shell compatible variable name.
-    <segun>.SegP
+    SegP or <segun>.SegP
       The path to the makefile segment.
-    <segun>.SegF
+    SegF or <segun>.SegF
       The path and name of the makefile segment. This can be used as part of a
       dependency list.
-    <segun>.SegD
+    SegD or <segun>.SegD
       A one line description for the segment.
 endef
 help-${_var} := $(call _help)
@@ -1920,6 +1956,8 @@ Callable-Macro  The name of a callable macro available to all segments.
 _private-macro or _Private-Macro
                 A private macro specific to a segment.
 
+$(call Display-Help-List,${SegID})
+
 Optionally defined before including helpers:
 DefaultGoal = ${DefaultGoal}
   This sets .DEFAULT_GOAL only if no other goals have been set and defaults
@@ -1968,6 +2006,7 @@ Platform = $(Platform)
   Microsoft, Linux, or OsX.
 Errors = ${Errors}
   If not empty then errors have been reported.
+
 
 ${help-SegUNs}
 

--- a/helpers.mk
+++ b/helpers.mk
@@ -601,7 +601,7 @@ ${_macro} = $(shell tr '[:lower:]' '[:upper:]' <<< $(1))
 _macro := Is-Not-Defined
 define _help
 ${_macro}
-  Returns a non-empty value if a variable is not defined.
+  Returns an non-empty value if a variable is not defined.
   Parameters:
     1 = The name of the variable to check.
 endef
@@ -625,7 +625,7 @@ $(strip \
   $(eval __r :=)
   $(foreach __v,$(1),
     $(call Debug,Requiring: ${__v})
-    $(if $(findstring undefined,$(flavor ${__v})),
+    $(if $(call Is-Not-Defined,${__v}),
       $(eval __r += ${__v})
       $(call Signal-Error,${Caller} requires variable ${__v} must be defined.)
     )
@@ -682,7 +682,7 @@ define ${_macro}
     $(call Signal-Error,Var $(1) has already been declared.)
   ,
     $(eval OverridableVars += $(1))
-    $(if $(filter $(origin $(1)),undefined),
+    $(if $(call Is-Not-Defined,$(1)),
       $(eval $(1) := $(2))
     ,
       $(call Debug,Var $(1) has override value: ${$(1)})
@@ -1287,7 +1287,7 @@ define ${_macro}
   $(call Debug,Resolving help goals.)
   $(call Debug,Help goals: $(filter help%,${Goals}))
   $(foreach __s,$(patsubst help-%,%,$(filter help-%,${Goals})),
-    $(if $(findstring undefined,$(flavor help-${__s})),
+    $(if $(call Is-Not-Defined,help-${__s}),
       $(call Debug,Resolving help for help-${__s})
       $(if $(filter \
         ${__s},2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20),
@@ -1296,7 +1296,7 @@ define ${_macro}
         $(call Signal-Error,Segment ID ${__s} does not exist -- no help.)
       ,
         $(call Use-Segment,$(subst .,/,${__s}).mk)
-        $(if $(findstring undefined,$(flavor help-${__s})),
+        $(if $(call Is-Not-Defined,help-${__s}),
           $(call Signal-Error,help-${__s} is undefined.)
         )
       )
@@ -1589,7 +1589,7 @@ define ${_macro}
     )
     $(call Debug,Flavor of ${__sn} is:$(flavor ${__sn}))
     $(eval __save :=)
-    $(if $(filter $(flavor ${__sn}),undefined),
+    $(if $(call Is-Not-Defined,${__sn}),
       $(call Debug,Defining ${__sn})
       $(if $(findstring =,$(1)),
         $(eval __sv := $(wordlist 2,$(words ${__snl}),${__snl}))
@@ -1747,7 +1747,7 @@ define ${_macro}
     $(eval $(1).MoreHelpList := )
     $(foreach __sym,${$(1)},
       $(call Debug,Adding help for:${__sym})
-      $(if $(filter $(origin help-${__sym}),undefined),
+      $(if $(call Is-Not-Defined,help-${__sym}),
         $(call Warn,Undefined help message: help-${__sym})
       ,
         $(eval $(1).MoreHelpList += help-${__sym})
@@ -1816,7 +1816,7 @@ call-%:
 
 help-%:
 > $(file >${TmpPath}/help-$*,${help-$*})
-> $(if $(findstring undefined,$(flavor $*.MoreHelpList)),,\
+> $(if $(call Is-Not-Defined,$*.MoreHelpList),,\
     $(if ${$*.MoreHelpList},\
       $(foreach _h,${$*.MoreHelpList},\
         $(file >>${TmpPath}/help-$*,==== ${__h} ====)\

--- a/helpers.mk
+++ b/helpers.mk
@@ -598,6 +598,16 @@ endef
 help-${_macro} := $(call _help)
 ${_macro} = $(shell tr '[:lower:]' '[:upper:]' <<< $(1))
 
+_macro := Is-Not-Defined
+define _help
+${_macro}
+  Returns a non-empty value if a variable is not defined.
+  Parameters:
+    1 = The name of the variable to check.
+endef
+help-${_macro} := $(call _help)
+${_macro} = $(filter undefined,$(flavor $(1)))
+
 _macro := Require
 define _help
 ${_macro}
@@ -1953,6 +1963,8 @@ ${help-Add-Var}
 ${help-Sub-Var}
 
 ${help-To-Shell-Var}
+
+${help-Is-Not-Defined}
 
 ${help-Require}
 

--- a/helpers.mk
+++ b/helpers.mk
@@ -657,6 +657,8 @@ ${_macro}
   Emit a debugging message. All debug messages are automatically added to the
   message list. Debug messages are prefixed with dbug.
   This is disabled unless DEBUG is not empty.
+  Debug messages are reserved for development. After development is complete
+  either remove the Debug messages or change them to Verbose.
   NOTE: This is NOT intended to be used as part of a recipe.
   Parameters:
     1 = The message to display.

--- a/helpers.mk
+++ b/helpers.mk
@@ -1198,7 +1198,7 @@ $.endef
 
 $$(call Info,New segment: Add variables, macros, goals, and recipes here.)
 # Remove the following line after completing this segment.
-$$(call Signal-Error,This segment has not yet been completed.)
+$$(call Signal-Error,Segment $${Seg} has not yet been completed.)
 
 # The command line goal for the segment.
 $${LastSegUN}: $${SegF}

--- a/helpers.mk
+++ b/helpers.mk
@@ -1530,6 +1530,17 @@ ${_var} = ${${_var}}
 endef
 help-${_var} := $(call _help)
 
+_macro := Is-Sticky
+define _help
+${_macro}
+  Returns the variable name if the variable is a sticky variable -- meaning
+  its value has been saved.
+  Parameters:
+    1 = The sticky variable to check.
+endef
+help-${_macro} := $(call _help)
+${_macro} = $(wildcard ${STICKY_PATH}/$(1))
+
 _macro := Sticky
 define _help
 ${_macro}
@@ -1596,7 +1607,7 @@ define ${_macro}
         $(eval __save := 1)
         $(call Debug,Setting ${__sn} to:"${__sv}".)
       ,
-        $(if $(wildcard ${__sf}),
+        $(if $(call Is-Sticky,${__sn}),
           $(call Debug,Reading previously saved value for ${__sn})
           $(eval __sv := $(file <${__sf}))
         ,
@@ -1625,7 +1636,7 @@ define ${_macro}
       $(if ${SubMake},
         $(call Debug,Variables are read-only in a sub-make.)
       ,
-        $(if $(wildcard ${__sf}),
+        $(if $(call Is-Sticky,${__sn}),
           $(call Debug,Replacing sticky:${__sf})
         ,
           $(call Debug,Creating sticky:${__sf})
@@ -1975,6 +1986,10 @@ ${help-Overridable}
 ++++ Sticky (persistent) variables
 
 ${help-Sticky}
+
+${help-Is-Sticky}
+
+${help-Redirect-Sticky}
 
 ${help-Redefine-Sticky}
 

--- a/suite-template.mk
+++ b/suite-template.mk
@@ -7,6 +7,20 @@ ifndef ${LastSegUN}.SegID
 $(call Enter-Segment,<purpose for this test suite segment>.)
 # -----
 
+define _help
+Make test suite: ${Seg}.mk
+
+<make test suite help messages>
+
+Command line goals:
+  help-${Seg} or help-${SegUN} or help-${SegID}
+    Display this help.
+endef
+help-${SegID} := $(call _help)
+$(call Add-Help,${SegID})
+
+$(call Add-Help-Section,TestList,Test list.)
+
 $(call Declare-Suite,${Seg},<description>)
 
 ${.SuiteN}.Prereqs :=
@@ -19,6 +33,7 @@ ${.TestUN}
   Verify the macro:$(call Get-Test-Name,${.TestUN})
 endef
 help-${.TestUN} := $(call _help)
+$(call Add-Help,${.TestUN})
 ${.TestUN}.Prereqs :=
 define ${.TestUN}
   $(call Enter-Macro,$(0))
@@ -40,17 +55,7 @@ __h := \
     $(call Is-Goal,help-${SegID}))
 ifneq (${__h},)
 define __help
-Make test suite: ${Seg}.mk
-
-<make test suite help messages>
-
-Tests:
-$(foreach __t,${${.SuiteN}.TestL},
-${help-${__t}})
-
-Command line goals:
-  help-${Seg} or help-${SegUN} or help-${SegID}
-    Display this help.
+$(call Display-Help-List,${SegID})
 endef
 ${__h} := ${__help}
 endif # help goal message.

--- a/test-helpers.mk
+++ b/test-helpers.mk
@@ -551,6 +551,22 @@ define ${_macro}
   )
 endef
 
+_macro := Expect-No-Warning
+define _help
+${_macro}
+  Enables (arm) Oneshot-Warning-Callback as a callback and sets
+  Expected_Warning to empty. The next call should be one which could generate a
+  warning. That should be followed by a call to Verify-No-Warning.
+endef
+help-${_macro} := $(call _help)
+define ${_macro}
+  $(call Enter-Macro,$(0))
+  $(eval Expected_Warning :=)
+  $(eval Actual_Warning :=)
+  $(call Set-Warning-Callback,Oneshot-Warning-Callback)
+  $(call Exit-Macro)
+endef
+
 _macro := Verify-No-Warning
 define _help
 ${_macro}
@@ -567,7 +583,7 @@ endef
 help-${_macro} := $(call _help)
 define ${_macro}
   $(if ${Actual_Warning},
-    $(call FAIL,An unexpected warning occurred.)
+    $(call FAIL,Unexpected:${Actual_Warning})
   ,
     $(call PASS,Warning did not occur -- as expected.)
     $(call Set-Warning-Callback)
@@ -631,20 +647,34 @@ define ${_macro}
   )
 endef
 
+_macro := Expect-No-Error
+define _help
+${_macro}
+  Enables (arm) Oneshot-Error-Callback as an error handler and sets
+  Expected_Error to empty. NOTE: Verify-No-Error must be called to verify that
+  the error did not occur.
+endef
+help-${_macro} := $(call _help)
+define ${_macro}
+  $(eval Expected_Error :=)
+  $(eval Actual_Error :=)
+  $(call Set-Error-Callback,Oneshot-Error-Callback)
+endef
+
 _macro := Verify-No-Error
 define _help
 ${_macro}
-  Verifies Oneshot-Error-Callback was not called since calling Expect-Error.
+  Verifies Oneshot-Error-Callback was not called since calling Expect-No-Error.
   A PASS is recorded If the error has NOT occurred. Otherwise a FAIL is
   recorded.
   This also disables the error handler to avoid confusing subsequent tests.
-  NOTE: For this to work Expect-Error must be called to arm the one-shot
+  NOTE: For this to work Expect-No-Error must be called to arm the one-shot
   handler.
 endef
 help-${_macro} := $(call _help)
 define ${_macro}
   $(if ${Actual_Error},
-    $(call FAIL,An unexpected error occurred.)
+    $(call FAIL,Unexpected:${Actual_Error})
   ,
     $(call PASS,Error did not occur -- as expected.)
     $(call Set-Error-Callback)
@@ -967,6 +997,9 @@ ${_macro}
   it will be skipped. A reference to a prerequisite test has the format:
     <seg>.<test>
   The segment <seg> is loaded if it has not already been loaded.
+
+  Prerequisite tests are run recursively. If a prerequisite test has
+  prerequisites then its prerequisites are run first.
 
   Parameters:
     1 = The test for which the prerequisites should be run.
@@ -1482,6 +1515,8 @@ ${help-Oneshot-Error-Callback}
 ${help-Expect-Error}
 
 ${help-Verify-Error}
+
+${help-Expect-No-Error}
 
 ${help-Verify-No-Error}
 

--- a/test-helpers.mk
+++ b/test-helpers.mk
@@ -3,7 +3,7 @@
 #-----------------------------------------------------------------------------
 # +++++
 $(call Last-Segment-UN)
-$(call Debug,$(call Last-Segment-Basename) UN:${LastSegUN})
+$(call Verbose,$(call Last-Segment-Basename) UN:${LastSegUN})
 ifndef ${LastSegUN}.SegID
 $(call Enter-Segment,\
   Test helpers for testing makefile segments and macros.)
@@ -499,7 +499,7 @@ define ${_macro}
   $(call Enter-Macro,$(0),$(1))
   $(foreach _e,$(1),
     $(eval _ve := $(subst :,${Space},${_e}))
-    $(call Debug,(${_ve}) Expecting:($(word 1,${_ve}))=($(word 2,${_ve})))
+    $(call Verbose,(${_ve}) Expecting:($(word 1,${_ve}))=($(word 2,${_ve})))
     $(if $(word 2,${_ve}),
       $(if $(filter ${$(word 1,${_ve})},$(word 2,${_ve})),
         $(call PASS,Expecting:(${_e}))
@@ -535,14 +535,14 @@ help-${_macro} := $(call _help)
 $(call Add-Help,${_macro})
 define ${_macro}
   $(call Enter-Macro,$(0),$(1) $(2))
-  $(call Debug,Expecting:"$(1)")
-  $(call Debug,Actual:"$(2)")
+  $(call Verbose,Expecting:"$(1)")
+  $(call Verbose,Actual:"$(2)")
   $(eval _i := 0)
   $(eval _ex := )
   $(foreach _w,$(1),
     $(call Inc-Var,_i)
     $(if $(filter ${_w},$(word ${_i},$(2))),
-      $(call Debug,${_w} = $(word ${_i},$(2)))
+      $(call Verbose,${_w} = $(word ${_i},$(2)))
     ,
       $(eval _ex += ${_i})
     )
@@ -571,8 +571,8 @@ help-${_macro} := $(call _help)
 $(call Add-Help,${_macro})
 define ${_macro}
   $(call Enter-Macro,$(0),$(1) $(2))
-  $(call Debug,Expecting:"$(1)")
-  $(call Debug,Actual:"$(2)")
+  $(call Verbose,Expecting:"$(1)")
+  $(call Verbose,Actual:"$(2)")
   $(call Expect-List,$(1),$(2))
   $(call Exit-Macro)
 endef
@@ -684,7 +684,7 @@ define ${_macro}
   $(call Enter-Macro,$(0),$(1))
   $(call Set-Warning-Callback)
   $(eval Actual_Warning := $(1))
-  $(call Debug,Actual warning:$(1))
+  $(call Verbose,Actual warning:$(1))
   $(call Expect-String,${Expected_Warning},${Actual_Warning})
   $(call Exit-Macro)
 endef
@@ -1025,7 +1025,7 @@ define ${_macro}
         $(call Signal-Error,\
           Suite $(2) has already been added to context ${_ctx}.)
       ,
-        $(call Debug,Adding suite $(2) to $(1) context.)
+        $(call Verbose,Adding suite $(2) to $(1) context.)
         $(call Inc-Var,${_ctx}.SuiteC)
         $(eval ${_ctx}.SuiteL += $(2))
       )
@@ -1056,7 +1056,7 @@ define ${_macro}
           $(call Signal-Error,\
             Test $(_t) has already been added to context ${_ctx}.)
         ,
-          $(call Debug,Adding test ${_t} to ${_ctx} context.)
+          $(call Verbose,Adding test ${_t} to ${_ctx} context.)
           $(call Inc-Var,${_ctx}.TestC)
           $(eval ${_ctx}.TestL += $(_t))
         )
@@ -1289,7 +1289,7 @@ define ${_macro}
   $(call Enter-Macro,$(0),$(1))
   $(if ${$(1).Prereqs},
     $(eval Prereq.Running := 1)
-    $(call Debug,$(1) prereqs:${$(1).Prereqs})
+    $(call Verbose,$(1) prereqs:${$(1).Prereqs})
     $(foreach _prereq,${$(1).Prereqs},
       $(if ${${_prereq}.Completed},
         $(call Test-Info,Test ${_prereq} has already completed -- skipping.)
@@ -1300,13 +1300,13 @@ define ${_macro}
       ,
         $(call Test-Info,Running prerequisite:${_prereq}.)
         $(eval _st := $(call Get-Suite-Name,${_prereq}))
-        $(call Debug,Prerequisite suite:${_st})
+        $(call Verbose,Prerequisite suite:${_st})
         $(if ${${_st}.SegID},
-          $(call Debug,The suite containing ${_prereq} is in use.)
+          $(call Verbose,The suite containing ${_prereq} is in use.)
         ,
           $(call Use-Segment,${_st})
         )
-        $(call Debug,Prereq ${_prereq} origin:$(origin ${_prereq}))
+        $(call Verbose,Prereq ${_prereq} origin:$(origin ${_prereq}))
         $(if $(filter undefined,$(origin ${_prereq})),
           $(call Signal-Error,Prereq test ${_prereq} is undefined.)
           $(eval Prereq.Failed := 1)
@@ -1404,11 +1404,11 @@ define ${_macro}
       $(eval _cases := $(call Basenames-In,${SUITES_PATH}/*.mk))
     )
   )
-  $(call Debug,Parsing:${_cases})
+  $(call Verbose,Parsing:${_cases})
   $(foreach _case,${_cases},
     $(eval _s := $(call Get-Suite-Name,${_case}))
     $(eval _t := $(call Get-Test-Name,${_case}))
-    $(call Debug,Parsing test(s):${_t})
+    $(call Verbose,Parsing test(s):${_t})
     $(if ${_s},
       $(eval _suite := ${_s})
     ,
@@ -1425,13 +1425,13 @@ define ${_macro}
     )
     $(if ${_t},
       $(eval _tl := $(subst +, ,${_t}))
-      $(call Debug,Test list:${_tl})
+      $(call Verbose,Test list:${_tl})
       $(foreach _test,${_tl},
-        $(call Debug,Parsing test(s):${_test})
+        $(call Verbose,Parsing test(s):${_test})
         $(eval _t2 := $(filter ${_suite}.${_test},${${_suite}.TestL}))
-        $(call Debug,Checking test:${_t2})
+        $(call Verbose,Checking test:${_t2})
         $(if ${_t2},
-          $(call Debug,Adding test:${_t2})
+          $(call Verbose,Adding test:${_t2})
           $(call Add-Tests-To-Contexts,Run,${_t2})
         ,
           $(call Signal-Error,\
@@ -1439,7 +1439,7 @@ define ${_macro}
         )
       )
     ,
-      $(call Debug,Adding suite ${_suite} to Run context.)
+      $(call Verbose,Adding suite ${_suite} to Run context.)
       $(call Add-Tests-To-Contexts,Run,${${_suite}.TestL})
     )
   )
@@ -1479,11 +1479,11 @@ define ${_macro}
   $(call Add-Segment-Path,$(1))
   $(call Create-Run-List,$(2))
   $(if $(call Is-Goal,help-Run.SuiteL),
-    $(call Debug,Building Run.SuiteL help list.)
+    $(call Verbose,Building Run.SuiteL help list.)
     $(call More-Help,Run.SuiteL)
   )
   $(if $(call Is-Goal,help-Run.TestL),
-    $(call Debug,Building Run.TestL help list.)
+    $(call Verbose,Building Run.TestL help list.)
     $(call More-Help,Run.TestL)
   )
   $(call Exit-Macro)

--- a/test-suites/expect-tests.mk
+++ b/test-suites/expect-tests.mk
@@ -7,6 +7,20 @@ ifndef ${LastSegUN}.SegID
 $(call Enter-Segment,Verify the helper macros for expecting values and results.)
 # -----
 
+define _help
+Make test suite: ${Seg}.mk
+
+This test suite verifies the variety of expect macros.
+
+Command line goals:
+  help-${SegUN}
+    Display this help.
+endef
+help-${SegID} := $(call _help)
+$(call Add-Help,${SegID})
+
+$(call Add-Help-Section,TestList,Test list.)
+
 $(call Declare-Suite,${Seg},Verify the variable related helper macros.)
 
 # Define the tests in the order in which they should be run.
@@ -17,6 +31,7 @@ ${.TestUN}
   Verify Expect-Vars for both passing and failing.
 endef
 help-${.TestUN} := $(call _help)
+$(call Add-Help,${.TestUN})
 ${.TestUN}.Prereqs := ${.SuiteN}.Set-Expected-Results
 define ${.TestUN}
   $(call Enter-Macro,$(0))
@@ -48,33 +63,34 @@ ${.TestUN}
   Verify a list of expected results will produce the correct test results.
 endef
 help-${.TestUN} := $(call _help)
+$(call Add-Help,${.TestUN})
 ${.TestUN}.Prereqs :=
 define ${.TestUN}
   $(call Enter-Macro,$(0))
   $(call Begin-Test,$(0))
 
   $(call Set-Expected-Results,PASS)
-  $(call Debug,ExpectedResultsL:${ExpectedResultsL})
+  $(call Verbose,ExpectedResultsL:${ExpectedResultsL})
   $(call PASS,This should PASS:PASS.)
   $(if ${ExpectedResultsL},
     $(call FAIL,ExpectedResultsL should be empty.)
   ,
     $(call PASS,ExpectedResultsL is empty.)
   )
-  $(call Debug,ExpectedResultsL:${ExpectedResultsL})
+  $(call Verbose,ExpectedResultsL:${ExpectedResultsL})
   $(call PASS,This should not call Verify-Result.)
 
   $(call Set-Expected-Results,FAIL)
-  $(call Debug,ExpectedResultsL:${ExpectedResultsL})
+  $(call Verbose,ExpectedResultsL:${ExpectedResultsL})
   $(call FAIL,This should PASS:FAIL.)
-  $(call Debug,ExpectedResultsL:${ExpectedResultsL})
+  $(call Verbose,ExpectedResultsL:${ExpectedResultsL})
   $(call PASS,This should not call Verify-Result.)
-  $(call Debug,ExpectedResultsL:${ExpectedResultsL})
+  $(call Verbose,ExpectedResultsL:${ExpectedResultsL})
 
   $(call Set-Expected-Results,PASS PASS FAIL FAIL FAIL)
-  $(call Debug,ExpectedResultsL:${ExpectedResultsL})
+  $(call Verbose,ExpectedResultsL:${ExpectedResultsL})
   $(call PASS,This should PASS:PASS.)
-  $(call Debug,ExpectedResultsL:${ExpectedResultsL})
+  $(call Verbose,ExpectedResultsL:${ExpectedResultsL})
   $(if ${.Failed},
     $(call Test-Info,Test has already failed -- skipping FAIL reset.)
     $(call FAIL,This should FAIL:PASS.)
@@ -88,9 +104,9 @@ define ${.TestUN}
       $(call Record-FAIL)
     )
   )
-  $(call Debug,ExpectedResultsL:${ExpectedResultsL})
+  $(call Verbose,ExpectedResultsL:${ExpectedResultsL})
   $(call FAIL,This should PASS:FAIL.)
-  $(call Debug,ExpectedResultsL:${ExpectedResultsL})
+  $(call Verbose,ExpectedResultsL:${ExpectedResultsL})
   $(if ${.Failed},
     $(call Test-Info,Test has already failed -- skipping FAIL reset.)
     $(call PASS,This should FAIL:FAIL.)
@@ -104,9 +120,9 @@ define ${.TestUN}
       $(call Record-FAIL)
     )
   )
-  $(call Debug,ExpectedResultsL:${ExpectedResultsL})
+  $(call Verbose,ExpectedResultsL:${ExpectedResultsL})
   $(call FAIL,This should PASS:FAIL.)
-  $(call Debug,ExpectedResultsL:${ExpectedResultsL})
+  $(call Verbose,ExpectedResultsL:${ExpectedResultsL})
   $(if ${ExpectedResultsL},
     $(call FAIL,ExpectedResultsL should be empty.)
   ,
@@ -123,6 +139,7 @@ ${.TestUN}
   Verify Expect-List for both passing and failing.
 endef
 help-${.TestUN} := $(call _help)
+$(call Add-Help,${.TestUN})
 ${.TestUN}.Prereqs := ${.SuiteN}.Set-Expected-Results
 define ${.TestUN}
   $(call Enter-Macro,$(0))
@@ -147,6 +164,7 @@ ${.TestUN}
   Verify Expect-List for both passing and failing.
 endef
 help-${.TestUN} := $(call _help)
+$(call Add-Help,${.TestUN})
 ${.TestUN}.Prereqs := ${.SuiteN}.Set-Expected-Results
 define ${.TestUN}
   $(call Enter-Macro,$(0))
@@ -176,17 +194,7 @@ __h := \
     $(call Is-Goal,help-${SegID}))
 ifneq (${__h},)
 define __help
-Make test suite: ${Seg}.mk
-
-This test suite verifies the variety of expect macros.
-
-Tests:
-$(foreach __t,${${.SuiteN}.TestL},
-${help-${__t}})
-
-Command line goals:
-  help-${SegUN}
-    Display this help.
+$(call Display-Help-List,${SegID})
 endef
 ${__h} := ${__help}
 endif # help goal message.

--- a/test-suites/sticky-tests.mk
+++ b/test-suites/sticky-tests.mk
@@ -71,7 +71,7 @@ define ${.TestUN}
 
   $(call Test-Info,Verify NO redefinition warning.)
   $(eval _vn2 := sticky2)
-  $(call Expect-Warning,Redefinition of sticky variable ${_vn2} ignored.)
+  $(call Expect-No-Warning)
   $(call Sticky,${_vn2},new)
   $(call Verify-No-Warning)
 
@@ -161,7 +161,7 @@ define ${.TestUN}
   $(call Expect-String,${_vn1g},${${_vn1}})
 
   $(eval _vn1v := new ${_vn1})
-  $(call Expect-Error,Var ${_vn1} has not been defined.)
+  $(call Expect-No-Error)
   $(call Redefine-Sticky,${_vn1}=${_vn1v})
   $(call Verify-No-Error)
   $(eval _vn1g := ${${_vn1}})
@@ -171,7 +171,7 @@ define ${.TestUN}
   $(eval _vn1v := new ${_vn1})
   $(eval SubMake := 1)
   $(call Expect-Warning,Cannot overwrite ${_vn1} in a submake.)
-  $(call Expect-Error,Var ${_vn1} has not been defined.)
+  $(call Expect-No-Error)
   $(call Redefine-Sticky,${_vn1}=${_vn1v})
   $(call Verify-No-Error)
   $(call Verify-Warning)
@@ -219,7 +219,7 @@ define ${.TestUN}
   $(call Expect-String,${_vn1g},${${_vn1}})
 
   $(call Test-Info,Verify sticky variable has been removed.)
-  $(call Expect-Error,Var ${_vn1} has not been defined.)
+  $(call Expect-No-Error)
   $(call Remove-Sticky,${_vn1})
   $(call Verify-No-Error)
 

--- a/test-suites/sticky-tests.mk
+++ b/test-suites/sticky-tests.mk
@@ -7,6 +7,20 @@ ifndef ${LastSegUN}.SegID
 $(call Enter-Segment,Test the macros and variables related to Sticky variables.)
 # -----
 
+define _help
+Make test suite: ${Seg}.mk
+
+Verify the macros and variables used for maintaining sticky variables.
+
+Command line goals:
+  help-${SegUN}
+    Display this help.
+endef
+help-${SegID} := $(call _help)
+$(call Add-Help,${SegID})
+
+$(call Add-Help-Section,TestList,Test list.)
+
 $(call Declare-Suite,${Seg},Verify the Sticky variable macros.)
 
 ${.SuiteN}.Prereqs :=
@@ -22,6 +36,7 @@ ${.TestUN}
   this macro is called. These are first verified to have correct values.
 endef
 help-${.TestUN} := $(call _help)
+$(call Add-Help,${.TestUN})
 ${.TestUN}.Prereqs := expect-tests.Expect-String
 define ${.TestUN}
   $(call Enter-Macro,$(0))
@@ -148,6 +163,7 @@ ${.TestUN}
   Verify the macro:$(call Get-Test-Name,${.TestUN})
 endef
 help-${.TestUN} := $(call _help)
+$(call Add-Help,${.TestUN})
 ${.TestUN}.Prereqs := ${.SuiteN}.Sticky test-vars.Compare-Strings
 define ${.TestUN}
   $(call Enter-Macro,$(0))
@@ -206,6 +222,7 @@ ${.TestUN}
   Verify the macro:$(call Get-Test-Name,${.TestUN})
 endef
 help-${.TestUN} := $(call _help)
+$(call Add-Help,${.TestUN})
 ${.TestUN}.Prereqs := ${.SuiteN}.Redefine-Sticky
 define ${.TestUN}
   $(call Enter-Macro,$(0))
@@ -242,17 +259,7 @@ __h := \
     $(call Is-Goal,help-${SegID}))
 ifneq (${__h},)
 define __help
-Make test suite: ${Seg}.mk
-
-Verify the macros and variables used for maintaining sticky variables.
-
-Tests:
-$(foreach __t,${${.SuiteN}.TestL},
-${help-${__t}})
-
-Command line goals:
-  help-${SegUN}
-    Display this help.
+$(call Display-Help-List,${SegID})
 endef
 ${__h} := ${__help}
 endif # help goal message.

--- a/test-suites/var-tests.mk
+++ b/test-suites/var-tests.mk
@@ -7,6 +7,20 @@ ifndef ${LastSegUN}.SegID
 $(call Enter-Segment,Verify the helper macros for manipulating variables.)
 # -----
 
+define _help
+Make test suite: ${Seg}.mk
+
+A series of tests to verify the helpers variable related macros.
+
+Command line goals:
+  help-${Seg} or help-${SegUN} or help-${SegID}
+    Display this help.
+endef
+help-${SegID} := $(call _help)
+$(call Add-Help,${SegID})
+
+$(call Add-Help-Section,TestList,Test list.)
+
 $(call Declare-Suite,${Seg},Verify the variable related helper macros.)
 
 # Define the tests in the order in which they should be run.
@@ -17,6 +31,7 @@ ${.TestUN}
   Verify the helper macro:$(call Get-Test-Name,${.TestUN})
 endef
 help-${.TestUN} := $(call _help)
+$(call Add-Help,${.TestUN})
 ${.TestUN}.Prereqs := expect-tests.Expect-Vars
 define ${.TestUN}
   $(call Enter-Macro,$(0))
@@ -38,6 +53,7 @@ ${.TestUN}
   Verify the helper macro:$(call Get-Test-Name,${.TestUN})
 endef
 help-${.TestUN} := $(call _help)
+$(call Add-Help,${.TestUN})
 ${.TestUN}.Prereqs := expect-tests.Expect-Vars
 define ${.TestUN}
   $(call Enter-Macro,$(0))
@@ -59,6 +75,7 @@ ${.TestUN}
   Verify the helper macro:$(call Get-Test-Name,${.TestUN})
 endef
 help-${.TestUN} := $(call _help)
+$(call Add-Help,${.TestUN})
 ${.TestUN}.Prereqs := expect-tests.Expect-Vars
 define ${.TestUN}
   $(call Enter-Macro,$(0))
@@ -98,6 +115,7 @@ ${.TestUN}
   Verify the helper macro:$(call Get-Test-Name,${.TestUN})
 endef
 help-${.TestUN} := $(call _help)
+$(call Add-Help,${.TestUN})
 ${.TestUN}.Prereqs := expect-tests.Expect-Vars
 define ${.TestUN}
   $(call Enter-Macro,$(0))
@@ -137,6 +155,7 @@ ${.TestUN}
   Verify the helper macro:$(call Get-Test-Name,${.TestUN})
 endef
 help-${.TestUN} := $(call _help)
+$(call Add-Help,${.TestUN})
 ${.TestUN}.Prereqs := expect-tests.Expect-Vars
 define ${.TestUN}
   $(call Enter-Macro,$(0))
@@ -155,6 +174,7 @@ ${.TestUN}
   Verify the helper macro:$(call Get-Test-Name,${.TestUN})
 endef
 help-${.TestUN} := $(call _help)
+$(call Add-Help,${.TestUN})
 ${.TestUN}.Prereqs := expect-tests.Expect-Vars
 define ${.TestUN}
   $(call Enter-Macro,$(0))
@@ -176,6 +196,7 @@ ${.TestUN}
   Verify the helper macro:$(call Get-Test-Name,${.TestUN})
 endef
 help-${.TestUN} := $(call _help)
+$(call Add-Help,${.TestUN})
 ${.TestUN}.Prereqs := expect-tests.Expect-Vars
 define ${.TestUN}
   $(call Enter-Macro,$(0))
@@ -197,6 +218,7 @@ ${.TestUN}
   Verify the helper macro:$(call Get-Test-Name,${.TestUN})
 endef
 help-${.TestUN} := $(call _help)
+$(call Add-Help,${.TestUN})
 ${.TestUN}.Prereqs :=
 define ${.TestUN}
   $(call Enter-Macro,$(0))
@@ -234,6 +256,7 @@ ${.TestUN}
   Verify the helper macro:$(call Get-Test-Name,${.TestUN})
 endef
 help-${.TestUN} := $(call _help)
+$(call Add-Help,${.TestUN})
 ${.TestUN}.Prereqs := expect-tests.Expect-List
 define ${.TestUN}
   $(call Enter-Macro,$(0))
@@ -283,6 +306,7 @@ ${.TestUN}
   Verify the helper macro:$(call Get-Test-Name,${.TestUN})
 endef
 help-${.TestUN} := $(call _help)
+$(call Add-Help,${.TestUN})
 ${.TestUN}.Prereqs :=
 define ${.TestUN}
   $(call Enter-Macro,$(0))
@@ -408,17 +432,7 @@ __h := \
     $(call Is-Goal,help-${SegID}))
 ifneq (${__h},)
 define __help
-Make test suite: ${Seg}.mk
-
-A series of tests to verify the helpers variable related macros.
-
-Tests:
-$(foreach __t,${${.SuiteN}.TestL},
-${help-${__t}})
-
-Command line goals:
-  help-${Seg} or help-${SegUN} or help-${SegID}
-    Display this help.
+$(call Display-Help-List,${SegID})
 endef
 ${__h} := ${__help}
 endif # help goal message.

--- a/test-suites/var-tests.mk
+++ b/test-suites/var-tests.mk
@@ -191,6 +191,39 @@ define ${.TestUN}
   $(call Exit-Macro)
 endef
 
+$(call Declare-Test,Is-Not-Defined)
+define _help
+${.TestUN}
+  Verify the helper macro:$(call Get-Test-Name,${.TestUN})
+endef
+help-${.TestUN} := $(call _help)
+${.TestUN}.Prereqs :=
+define ${.TestUN}
+  $(call Enter-Macro,$(0))
+  $(call Begin-Test,$(0))
+  $(eval _v := not-defined)
+  $(call Test-Info,Var _v is: $(flavor ${_v}))
+  $(eval _r := $(call Is-Not-Defined,${_v}))
+  $(call Test-Info,Is-Not-Defined returned:${_r})
+  $(if $(call Is-Not-Defined,${_v}),
+    $(call PASS,Is-Not-Defined says "${_v}" is not defined.)
+  ,
+    $(call FAIL,Is-Not-Defined says "${_v}" is defined.)
+  )
+  $(eval _v := is-defined)
+  $(eval ${_v} :=)
+  $(call Test-Info,Var _v is: $(flavor ${_v}))
+  $(eval _r := $(call Is-Not-Defined,${_v}))
+  $(call Test-Info,Is-Not-Defined returned:${_r})
+  $(if $(call Is-Not-Defined,${_v}),
+    $(call FAIL,Is-Not-Defined says "${_v}" is not defined.)
+  ,
+    $(call PASS,Is-Not-Defined says "${_v}" is defined.)
+  )
+  $(call End-Test)
+  $(call Exit-Macro)
+endef
+
 define _Require-Callback
 
 endef


### PR DESCRIPTION
This iteration adds macros to generate and display a list of help messages. This removes the need to manually maintain a list in a segment help.
Misc. changes for checking expected results and check sticky variable status.
All Debug messages have been changed to Verbose. The best practice for Debug now is to use Debug for a development iteration and either remove the Debug messages or change them to Verbose once development is complete.